### PR TITLE
Cascade actions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ matrix:
   include:
     - env: JOB_TYPE=eloquent
       script: 
- #       - cp dependency_repos.repos .ros2ci/additional_repos.repos
+        - cp dependency_repos.repos .ros2ci/additional_repos.repos
         - .ros2ci/travis.bash $JOB_TYPE
 

--- a/dependency_repos.repos
+++ b/dependency_repos.repos
@@ -1,0 +1,5 @@
+repositories:
+  cascade_lifecycle:
+    type: git
+    url: https://github.com/fmrico/cascade_lifecycle.git
+    version: master

--- a/plansys2_executor/CMakeLists.txt
+++ b/plansys2_executor/CMakeLists.txt
@@ -9,6 +9,8 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
+find_package(lifecycle_msgs REQUIRED)
+find_package(rclcpp_cascade_lifecycle REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 find_package(plansys2_pddl_parser REQUIRED)
 find_package(plansys2_msgs REQUIRED)
@@ -19,6 +21,8 @@ find_package(plansys2_planner REQUIRED)
 set(dependencies
     rclcpp
     rclcpp_lifecycle
+    lifecycle_msgs
+    rclcpp_cascade_lifecycle
     rclcpp_action
     plansys2_pddl_parser
     ament_index_cpp

--- a/plansys2_executor/include/plansys2_executor/ActionExecutorClient.hpp
+++ b/plansys2_executor/include/plansys2_executor/ActionExecutorClient.hpp
@@ -27,12 +27,13 @@
 #include "plansys2_domain_expert/Types.hpp"
 
 #include "rclcpp/rclcpp.hpp"
+#include "rclcpp_cascade_lifecycle/rclcpp_cascade_lifecycle.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
 
 namespace plansys2
 {
 
-class ActionExecutorClient : public rclcpp::Node
+class ActionExecutorClient : public rclcpp_cascade_lifecycle::CascadeLifecycleNode
 {
 public:
   using ExecuteAction = plansys2_msgs::action::ExecuteAction;
@@ -47,9 +48,6 @@ public:
 protected:
   virtual void actionStep() = 0;
   virtual bool isFinished() = 0;
-
-  virtual void onActivate() {}
-  virtual void onFinish() {}
 
   std::shared_ptr<ExecuteAction::Feedback> getFeedback() {return feedback_;}
   const std::vector<std::string> & getArguments() const {return arguments_;}

--- a/plansys2_executor/package.xml
+++ b/plansys2_executor/package.xml
@@ -15,6 +15,8 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_action</depend>
   <depend>rclcpp_lifecycle</depend>
+  <depend>lifecycle_msgs</depend>
+  <depend>rclcpp_cascade_lifecycle</depend>
   <depend>ament_index_cpp</depend>
   <depend>plansys2_pddl_parser</depend>
   <depend>plansys2_msgs</depend>


### PR DESCRIPTION
This PR changes `ActionExecutorClient` to inherit from `rclcpp_cascade_lifecycle::CascadeLifecycleNode`. This change lets to create actions that can activate other nodes needed for executing the action.