### PR TITLE
Explicitly include Boost_INCLUDE_DIRS

### DIFF
--- a/plansys2_domain_expert/CMakeLists.txt
+++ b/plansys2_domain_expert/CMakeLists.txt
@@ -34,6 +34,7 @@ set(DOMAIN_EXPERT_SOURCES
 
 add_library(${PROJECT_NAME} SHARED ${DOMAIN_EXPERT_SOURCES})
 ament_target_dependencies(${PROJECT_NAME} ${dependencies})
+target_include_directories(${PROJECT_NAME} PUBLIC ${Boost_INCLUDE_DIRS})
 
 add_executable(domain_expert_node
   src/domain_expert_node.cpp

--- a/plansys2_planner/CMakeLists.txt
+++ b/plansys2_planner/CMakeLists.txt
@@ -37,6 +37,7 @@ set(PLANNER_SOURCES
 
 add_library(${PROJECT_NAME} SHARED ${PLANNER_SOURCES})
 ament_target_dependencies(${PROJECT_NAME} ${dependencies})
+target_include_directories(${PROJECT_NAME} PUBLIC ${Boost_INCLUDE_DIRS})
 
 add_executable(planner_node
   src/planner_node.cpp

--- a/plansys2_problem_expert/CMakeLists.txt
+++ b/plansys2_problem_expert/CMakeLists.txt
@@ -33,6 +33,7 @@ set(PROBLEM_EXPERT_SOURCES
 
 add_library(${PROJECT_NAME} SHARED ${PROBLEM_EXPERT_SOURCES})
 ament_target_dependencies(${PROJECT_NAME} ${dependencies})
+target_include_directories(${PROJECT_NAME} PUBLIC ${Boost_INCLUDE_DIRS})
 
 add_executable(problem_expert_node
   src/problem_expert_node.cpp


### PR DESCRIPTION
This is necessary on systems where the Boost headers are not placed directly in /usr/include.