### PR TITLE
[Eloquent] Reduce unnecessary dependencies

### DIFF
--- a/plansys2_bringup/CMakeLists.txt
+++ b/plansys2_bringup/CMakeLists.txt
@@ -2,8 +2,6 @@ project(plansys2_bringup)
 
 cmake_minimum_required(VERSION 3.5)
 
-set(CMAKE_BUILD_TYPE RELEASE)
-
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(plansys2_domain_expert REQUIRED)

--- a/plansys2_executor/CMakeLists.txt
+++ b/plansys2_executor/CMakeLists.txt
@@ -75,12 +75,6 @@ if(BUILD_TESTING)
   find_package(test_msgs REQUIRED)
   find_package(geometry_msgs REQUIRED)
 
-  set(dependencies
-    ${dependencies}
-    test_msgs
-    geometry_msgs
-  )
-
   add_subdirectory(test)
 endif()
 

--- a/plansys2_executor/CMakeLists.txt
+++ b/plansys2_executor/CMakeLists.txt
@@ -2,8 +2,6 @@ project(plansys2_executor)
 
 cmake_minimum_required(VERSION 3.5)
 
-set(CMAKE_BUILD_TYPE RELEASE)
-
 find_package(Threads REQUIRED)
 
 find_package(ament_cmake REQUIRED)

--- a/plansys2_lifecycle_manager/CMakeLists.txt
+++ b/plansys2_lifecycle_manager/CMakeLists.txt
@@ -2,8 +2,6 @@ project(plansys2_lifecycle_manager)
 
 cmake_minimum_required(VERSION 3.5)
 
-set(CMAKE_BUILD_TYPE RELEASE)
-
 find_package(Threads REQUIRED)
 
 find_package(ament_cmake REQUIRED)

--- a/plansys2_pddl_parser/CMakeLists.txt
+++ b/plansys2_pddl_parser/CMakeLists.txt
@@ -2,8 +2,6 @@ project(plansys2_pddl_parser)
 
 cmake_minimum_required(VERSION 3.5)
 
-set(CMAKE_BUILD_TYPE RELEASE)
-
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 

--- a/plansys2_planner/CMakeLists.txt
+++ b/plansys2_planner/CMakeLists.txt
@@ -2,8 +2,6 @@ project(plansys2_planner)
 
 cmake_minimum_required(VERSION 3.5)
 
-set(CMAKE_BUILD_TYPE RELEASE)
-
 find_package(Threads REQUIRED)
 
 find_package(ament_cmake REQUIRED)

--- a/plansys2_problem_expert/CMakeLists.txt
+++ b/plansys2_problem_expert/CMakeLists.txt
@@ -2,8 +2,6 @@ project(plansys2_problem_expert)
 
 cmake_minimum_required(VERSION 3.5)
 
-set(CMAKE_BUILD_TYPE RELEASE)
-
 find_package(Threads REQUIRED)
 
 find_package(ament_cmake REQUIRED)

--- a/plansys2_terminal/CMakeLists.txt
+++ b/plansys2_terminal/CMakeLists.txt
@@ -2,8 +2,6 @@ project(plansys2_terminal)
 
 cmake_minimum_required(VERSION 3.5)
 
-set(CMAKE_BUILD_TYPE RELEASE)
-
 find_package(Threads REQUIRED)
 
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
`ament_export_dependencies` was incorrectly exporting dependencies that are only used for test (and marked as such in `package.xml`).

This also removes some `set(CMAKE_BUILD_TYPE RELEASE)`, because this is actually handled by the build or packaging system.  For instance `colcon --cmake-args -DCMAKE_BUILD_TYPE=Release`