### PR TITLE
[eloquent] Remove boost::optional

### DIFF
--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertNode.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertNode.hpp
@@ -15,8 +15,6 @@
 #ifndef PLANSYS2_DOMAIN_EXPERT__DOMAINEXPERTNODE_HPP_
 #define PLANSYS2_DOMAIN_EXPERT__DOMAINEXPERTNODE_HPP_
 
-#include <boost/optional.hpp>
-
 #include <memory>
 
 #include "plansys2_domain_expert/DomainExpert.hpp"

--- a/plansys2_executor/src/plansys2_executor/ActionBTExecutorClient.cpp
+++ b/plansys2_executor/src/plansys2_executor/ActionBTExecutorClient.cpp
@@ -64,7 +64,7 @@ ActionBTExecutorClient::atStart()
 void
 ActionBTExecutorClient::actionStep()
 {
-  auto result = tree_.rootNode()->executeTick();
+  auto result = tree_.root_node->executeTick();
 
   switch (result) {
     case BT::NodeStatus::SUCCESS:

--- a/plansys2_executor/test/unit/behavior_tree/RepeatServer.cpp
+++ b/plansys2_executor/test/unit/behavior_tree/RepeatServer.cpp
@@ -52,7 +52,7 @@ RepeaterServer::handle_goal(
     current_goal_ = *goal;
     return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
   } else {
-    rclcpp_action::GoalResponse::REJECT;
+    return rclcpp_action::GoalResponse::REJECT;
   }
 }
 


### PR DESCRIPTION
The boost::optional header was unused and was triggering a deb failure, so I removed it, along with some other adjustments to get the build fully working.

Signed-off-by: Michael Carroll <michael@openrobotics.org>