### PR TITLE
return a goal response even when rejected.

### DIFF
--- a/plansys2_executor/test/unit/behavior_tree/RepeatServer.cpp
+++ b/plansys2_executor/test/unit/behavior_tree/RepeatServer.cpp
@@ -52,7 +52,7 @@ RepeaterServer::handle_goal(
     current_goal_ = *goal;
     return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
   } else {
-    rclcpp_action::GoalResponse::REJECT;
+    return rclcpp_action::GoalResponse::REJECT;
   }
 }
 


### PR DESCRIPTION
The return of a goal response was previously forgotten,
generating a compilation warning.

Signed-off-by: Fabrice Larribe <fabrice.larribe@safrangroup.com>