### PR TITLE
Fix plugin import for popf

### DIFF
--- a/plansys2_core/CMakeLists.txt
+++ b/plansys2_core/CMakeLists.txt
@@ -7,10 +7,12 @@ find_package(Threads REQUIRED)
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
+find_package(pluginlib REQUIRED)
 
 set(dependencies
-    rclcpp
-    rclcpp_lifecycle
+  rclcpp
+  rclcpp_lifecycle
+  pluginlib
 )
 
 include_directories(include)

--- a/plansys2_core/package.xml
+++ b/plansys2_core/package.xml
@@ -14,6 +14,7 @@
 
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
+  <depend>pluginlib</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/plansys2_executor/package.xml
+++ b/plansys2_executor/package.xml
@@ -24,6 +24,7 @@
   <depend>plansys2_problem_expert</depend>
   <depend>plansys2_planner</depend>
   <depend>behaviortree_cpp_v3</depend>
+  <depend>pluginlib</depend>
 
   <exec_depend>popf</exec_depend>
 

--- a/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
+++ b/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
@@ -75,7 +75,7 @@ BTBuilder::get_tree(const Plan & current_plan)
     bt_plan = std::string("<root main_tree_to_execute=\"MainTree\">\n") +
       t(1) + "<BehaviorTree ID=\"MainTree\">\n" +
       t(2) + "<Parallel success_threshold=\"" + std::to_string(root_counters) +
-        "\" failure_threshold=\"1\">\n";
+      "\" failure_threshold=\"1\">\n";
 
     for (auto & level : levels) {
       for (auto & action_unit : level->action_units) {
@@ -212,7 +212,7 @@ BTBuilder::get_flow_tree(
     ret = ret +
       execution_block(root_flow->action, root_flow->time, l + 1) +
       t(l + 1) + "<Parallel success_threshold=\"" + std::to_string(succ(root_flow).size()) +
-        "\"  failure_threshold=\"1\">\n";
+      "\"  failure_threshold=\"1\">\n";
 
     for (auto & action : succ(root_flow)) {
       ret = ret + get_flow_tree(action, used_actions, l + 2);

--- a/plansys2_popf_plan_solver/CMakeLists.txt
+++ b/plansys2_popf_plan_solver/CMakeLists.txt
@@ -26,6 +26,10 @@ add_library(${PROJECT_NAME} SHARED
 )
 ament_target_dependencies(${PROJECT_NAME} ${dependencies})
 
+target_compile_definitions(${PROJECT_NAME} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+
+pluginlib_export_plugin_description_file(plansys2_core plansys2_popf_plan_solver_plugin.xml)
+
 install(TARGETS
   ${PROJECT_NAME}
   ARCHIVE DESTINATION lib
@@ -35,6 +39,10 @@ install(TARGETS
 
 install(DIRECTORY include/
   DESTINATION include/
+)
+
+install(FILES plansys2_popf_plan_solver_plugin.xml
+  DESTINATION share/${PROJECT_NAME}
 )
 
 if(BUILD_TESTING)
@@ -49,6 +57,5 @@ ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})
 ament_export_dependencies(${dependencies})
 
-pluginlib_export_plugin_description_file(plansys2_core plansys2_popf_plan_solver_plugin.xml)
 
 ament_package()

--- a/plansys2_popf_plan_solver/package.xml
+++ b/plansys2_popf_plan_solver/package.xml
@@ -26,6 +26,6 @@
 
   <export>
     <build_type>ament_cmake</build_type>
-    <plansys2_planner plugin="${prefix}/local_planner_plugin.xml" />
+    <plansys2_core plugin="${prefix}/plansys2_popf_plan_solver_plugin.xml" />
   </export>
 </package>


### PR DESCRIPTION
The export tag in `plansys2_popf_plan_solver` has been fixed to be correctly found.

Signed-off-by: Francisco Martin Rico <fmrico@gmail.com>