### PR TITLE
Default plugin as library

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           required-ros-distributions: foxy
       - name: build and test
-        uses: fmrico/action-ros-ci@0.1.1
+        uses: ros-tooling/action-ros-ci@0.1.0
         with:
           package-name: plansys2_bringup plansys2_bt_actions plansys2_domain_expert plansys2_executor plansys2_lifecycle_manager plansys2_msgs plansys2_pddl_parser plansys2_planner plansys2_popf_plan_solver plansys2_problem_expert plansys2_terminal
           target-ros2-distro: foxy

--- a/plansys2_planner/CMakeLists.txt
+++ b/plansys2_planner/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(plansys2_pddl_parser REQUIRED)
 find_package(plansys2_msgs REQUIRED)
 find_package(plansys2_domain_expert REQUIRED)
 find_package(plansys2_problem_expert REQUIRED)
+find_package(plansys2_popf_plan_solver REQUIRED)
 find_package(pluginlib REQUIRED)
 
 set(dependencies
@@ -26,6 +27,7 @@ set(dependencies
   plansys2_msgs
   plansys2_domain_expert
   plansys2_problem_expert
+  plansys2_popf_plan_solver
   pluginlib
 )
 

--- a/plansys2_planner/package.xml
+++ b/plansys2_planner/package.xml
@@ -21,6 +21,7 @@
   <depend>plansys2_msgs</depend>
   <depend>plansys2_domain_expert</depend>
   <depend>plansys2_problem_expert</depend>
+  <depend>plansys2_popf_plan_solver</depend>
   <depend>pluginlib</depend>
 
   <test_depend>ament_lint_common</test_depend>

--- a/plansys2_planner/src/plansys2_planner/PlannerNode.cpp
+++ b/plansys2_planner/src/plansys2_planner/PlannerNode.cpp
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "plansys2_planner/PlannerNode.hpp"
-#include "plansys2_popf_plan_solver/popf_plan_solver.hpp"
-
 #include <string>
 #include <memory>
 #include <iostream>
 #include <fstream>
+
+#include "plansys2_planner/PlannerNode.hpp"
+#include "plansys2_popf_plan_solver/popf_plan_solver.hpp"
 
 #include "lifecycle_msgs/msg/state.hpp"
 

--- a/plansys2_planner/test/unit/planner_test.cpp
+++ b/plansys2_planner/test/unit/planner_test.cpp
@@ -34,19 +34,6 @@
 
 #include "rclcpp/rclcpp.hpp"
 
-TEST(planner_expert, load_popf_plugin)
-{
-  try {
-    pluginlib::ClassLoader<plansys2::PlanSolverBase> lp_loader(
-      "plansys2_core", "plansys2::PlanSolverBase");
-    plansys2::PlanSolverBase::Ptr plugin =
-      lp_loader.createUniqueInstance("plansys2/POPFPlanSolver");
-    ASSERT_TRUE(true);
-  } catch (std::exception & e) {
-    std::cerr << e.what() << std::endl;
-    ASSERT_TRUE(false);
-  }
-}
 
 TEST(planner_expert, generate_plan_good)
 {


### PR DESCRIPTION
CI Tests fail when using plugins because we have to source first the workspace. This PR makes Popf the default plugin, but if loads it as library, not plugin. This should make pass the tests without sourcing the workspace.

Signed-off-by: Francisco Martin Rico <fmrico@gmail.com>