### PR TITLE
Transparent pddl

### DIFF
--- a/plansys2_core/CMakeLists.txt
+++ b/plansys2_core/CMakeLists.txt
@@ -19,16 +19,31 @@ set(dependencies
 
 include_directories(include)
 
+add_library(${PROJECT_NAME} SHARED
+  src/plansys2_core/Utils.cpp
+)
+
 install(DIRECTORY include/
   DESTINATION include/
+)
+
+install(TARGETS
+  ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
 )
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_gtest REQUIRED)
+  add_subdirectory(test)
 endif()
 
 ament_export_include_directories(include)
 ament_export_dependencies(${dependencies})
+ament_export_libraries(${PROJECT_NAME})
 
 ament_package()

--- a/plansys2_core/include/plansys2_core/Utils.hpp
+++ b/plansys2_core/include/plansys2_core/Utils.hpp
@@ -1,0 +1,28 @@
+// Copyright 2019 Intelligent Robotics Lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PLANSYS2_CORE__UTILS_HPP_
+#define PLANSYS2_CORE__UTILS_HPP_
+
+#include <string>
+#include <vector>
+
+namespace plansys2
+{
+
+std::vector<std::string> tokenize(const std::string & string, const std::string & delim);
+
+}  // namespace plansys2
+
+#endif  // PLANSYS2_CORE__UTILS_HPP_

--- a/plansys2_core/src/plansys2_core/Utils.cpp
+++ b/plansys2_core/src/plansys2_core/Utils.cpp
@@ -1,0 +1,42 @@
+// Copyright 2019 Intelligent Robotics Lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <vector>
+
+#include "plansys2_core/Utils.hpp"
+
+namespace plansys2
+{
+
+std::vector<std::string> tokenize(const std::string & string, const std::string & delim)
+{
+  std::string::size_type lastPos = 0, pos = string.find_first_of(delim, lastPos);
+  std::vector<std::string> tokens;
+
+  while (lastPos != std::string::npos) {
+    if (pos != lastPos) {
+      tokens.push_back(string.substr(lastPos, pos - lastPos));
+    }
+    lastPos = pos;
+    if (lastPos == std::string::npos || lastPos + 1 == string.length()) {
+      break;
+    }
+    pos = string.find_first_of(delim, ++lastPos);
+  }
+
+  return tokens;
+}
+
+}  // namespace plansys2

--- a/plansys2_core/test/CMakeLists.txt
+++ b/plansys2_core/test/CMakeLists.txt
@@ -1,0 +1,2 @@
+ament_add_gtest(utils_test utils_test.cpp)
+target_link_libraries(utils_test ${PROJECT_NAME})

--- a/plansys2_core/test/utils_test.cpp
+++ b/plansys2_core/test/utils_test.cpp
@@ -1,0 +1,49 @@
+// Copyright 2029 Intelligent Robotics Lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "plansys2_core/Utils.hpp"
+
+
+TEST(domain_expert, functions)
+{
+  std::string st1("this is a message");
+  std::vector<std::string> est1 = {"this", "is", "a", "message"};
+  std::vector<std::string> est1b = {"this", "a", "message"};
+  auto res1 = plansys2::tokenize(st1, " ");
+
+  ASSERT_EQ(res1, est1);
+  ASSERT_NE(res1, est1b);
+
+  std::string st2("this:is:a:message");
+  std::vector<std::string> est2 = {"this", "is", "a", "message"};
+  auto res2 = plansys2::tokenize(st2, ":");
+
+  ASSERT_EQ(res2, est2);
+
+  std::string st3("this       is a     message");
+  std::vector<std::string> est3 = {"this", "is", "a", "message"};
+  auto res3 = plansys2::tokenize(st3, " ");
+
+  ASSERT_EQ(res3, est3);
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/plansys2_domain_expert/CMakeLists.txt
+++ b/plansys2_domain_expert/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(rclcpp_lifecycle REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 find_package(plansys2_pddl_parser REQUIRED)
 find_package(plansys2_msgs REQUIRED)
+find_package(plansys2_core REQUIRED)
 
 set(CMAKE_CXX_STANDARD 17)
 
@@ -21,6 +22,7 @@ set(dependencies
     plansys2_pddl_parser
     ament_index_cpp
     plansys2_msgs
+    plansys2_core
 )
 
 include_directories(include)
@@ -28,6 +30,7 @@ include_directories(include)
 set(DOMAIN_EXPERT_SOURCES
   src/plansys2_domain_expert/DomainExpert.cpp
   src/plansys2_domain_expert/DomainExpertClient.cpp
+  src/plansys2_domain_expert/DomainReader.cpp
   src/plansys2_domain_expert/Types.cpp
   src/plansys2_domain_expert/DomainExpertNode.cpp
 )

--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpert.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpert.hpp
@@ -18,11 +18,13 @@
 #include <optional>
 #include <string>
 #include <vector>
+#include <memory>
 
 #include "plansys2_pddl_parser/Domain.h"
 
 #include "plansys2_domain_expert/DomainExpertInterface.hpp"
 #include "plansys2_domain_expert/Types.hpp"
+#include "plansys2_domain_expert/DomainReader.hpp"
 
 namespace plansys2
 {
@@ -112,7 +114,8 @@ public:
   std::string getDomain();
 
 private:
-  parser::pddl::Domain domain_;
+  std::shared_ptr<parser::pddl::Domain> domain_;
+  DomainReader domains_;
 };
 
 }  // namespace plansys2

--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainReader.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainReader.hpp
@@ -1,0 +1,56 @@
+// Copyright 2020 Intelligent Robotics Lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PLANSYS2_DOMAIN_EXPERT__DOMAINREADER_HPP_
+#define PLANSYS2_DOMAIN_EXPERT__DOMAINREADER_HPP_
+
+#include <string>
+#include <vector>
+
+namespace plansys2
+{
+
+struct Domain
+{
+  std::string requirements;
+  std::string types;
+  std::string predicates;
+  std::string functions;
+  std::vector<std::string> actions;
+};
+
+class DomainReader
+{
+public:
+  DomainReader();
+
+  void add_domain(const std::string & domain);
+  std::string get_joint_domain() const;
+
+protected:
+  int get_end_block(const std::string & domain, std::size_t init_pos);
+
+  std::string get_requirements(std::string & domain);
+  std::string get_types(const std::string & domain);
+  std::string get_predicates(const std::string & domain);
+  std::string get_functions(const std::string & domain);
+  std::vector<std::string> get_actions(const std::string & domain);
+
+private:
+  std::vector<Domain> domains_;
+};
+
+}  // namespace plansys2
+
+#endif  // PLANSYS2_DOMAIN_EXPERT__DOMAINREADER_HPP_

--- a/plansys2_domain_expert/package.xml
+++ b/plansys2_domain_expert/package.xml
@@ -18,6 +18,7 @@
   <depend>ament_index_cpp</depend>
   <depend>plansys2_pddl_parser</depend>
   <depend>plansys2_msgs</depend>
+  <depend>plansys2_core</depend>
  
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpert.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpert.cpp
@@ -18,41 +18,44 @@
 #include <algorithm>
 #include <string>
 #include <vector>
+#include <memory>
 
 
 namespace plansys2
 {
 
 DomainExpert::DomainExpert(const std::string & domain)
-: domain_(domain)
 {
+  extendDomain(domain);
 }
 
 void
 DomainExpert::extendDomain(const std::string & domain)
 {
-  domain_.parse(domain);
+  domains_.add_domain(domain);
+
+  domain_ = std::make_shared<parser::pddl::Domain>();
+  domain_->parse(domains_.get_joint_domain());
 }
 
 std::vector<std::string>
 DomainExpert::getTypes()
 {
   std::vector<std::string> ret;
-  if (domain_.typed) {
-    for (unsigned i = 1; i < domain_.types.size(); i++) {
-      ret.push_back(domain_.types[i]->name);
+  if (domain_->typed) {
+    for (unsigned i = 1; i < domain_->types.size(); i++) {
+      ret.push_back(domain_->types[i]->name);
     }
   }
   return ret;
 }
 
-
 std::vector<std::string>
 DomainExpert::getFunctions()
 {
   std::vector<std::string> ret;
-  for (unsigned i = 0; i < domain_.funcs.size(); i++) {
-    ret.push_back(domain_.funcs[i]->name);
+  for (unsigned i = 0; i < domain_->funcs.size(); i++) {
+    ret.push_back(domain_->funcs[i]->name);
   }
   return ret;
 }
@@ -61,8 +64,8 @@ std::vector<std::string>
 DomainExpert::getPredicates()
 {
   std::vector<std::string> ret;
-  for (unsigned i = 0; i < domain_.preds.size(); i++) {
-    ret.push_back(domain_.preds[i]->name);
+  for (unsigned i = 0; i < domain_->preds.size(); i++) {
+    ret.push_back(domain_->preds[i]->name);
   }
   return ret;
 }
@@ -85,16 +88,16 @@ std::optional<plansys2::Function> DomainExpert::getFunction(const std::string & 
   bool found = false;
   unsigned i = 0;
 
-  while (i < domain_.funcs.size() && !found) {
-    if (domain_.funcs[i]->name == function_search) {
+  while (i < domain_->funcs.size() && !found) {
+    if (domain_->funcs[i]->name == function_search) {
       found = true;
       ret.name = function_search;
-      for (unsigned j = 0; j < domain_.funcs[i]->params.size(); j++) {
+      for (unsigned j = 0; j < domain_->funcs[i]->params.size(); j++) {
         plansys2::Param param;
-        param.name = "?" + domain_.types[domain_.funcs[i]->params[j]]->getName() +
+        param.name = "?" + domain_->types[domain_->funcs[i]->params[j]]->getName() +
           std::to_string(j);
-        param.type = domain_.types[domain_.funcs[i]->params[j]]->getName();
-        domain_.types[domain_.funcs[i]->params[j]]->getSubTypesNames(param.subTypes);
+        param.type = domain_->types[domain_->funcs[i]->params[j]]->getName();
+        domain_->types[domain_->funcs[i]->params[j]]->getSubTypesNames(param.subTypes);
         ret.parameters.push_back(param);
       }
     }
@@ -108,7 +111,6 @@ std::optional<plansys2::Function> DomainExpert::getFunction(const std::string & 
   }
 }
 
-
 std::optional<plansys2::Predicate>
 DomainExpert::getPredicate(const std::string & predicate)
 {
@@ -121,16 +123,16 @@ DomainExpert::getPredicate(const std::string & predicate)
   bool found = false;
   unsigned i = 0;
 
-  while (i < domain_.preds.size() && !found) {
-    if (domain_.preds[i]->name == predicate_search) {
+  while (i < domain_->preds.size() && !found) {
+    if (domain_->preds[i]->name == predicate_search) {
       found = true;
       ret.name = predicate_search;
-      for (unsigned j = 0; j < domain_.preds[i]->params.size(); j++) {
+      for (unsigned j = 0; j < domain_->preds[i]->params.size(); j++) {
         plansys2::Param param;
-        param.name = "?" + domain_.types[domain_.preds[i]->params[j]]->getName() +
+        param.name = "?" + domain_->types[domain_->preds[i]->params[j]]->getName() +
           std::to_string(j);
-        param.type = domain_.types[domain_.preds[i]->params[j]]->name;
-        domain_.types[domain_.preds[i]->params[j]]->getSubTypesNames(param.subTypes);
+        param.type = domain_->types[domain_->preds[i]->params[j]]->name;
+        domain_->types[domain_->preds[i]->params[j]]->getSubTypesNames(param.subTypes);
         ret.parameters.push_back(param);
       }
     }
@@ -148,11 +150,11 @@ std::vector<std::string>
 DomainExpert::getActions()
 {
   std::vector<std::string> ret;
-  for (unsigned i = 0; i < domain_.actions.size(); i++) {
-    bool is_action = dynamic_cast<parser::pddl::TemporalAction *>(domain_.actions[i]) == nullptr;
-    parser::pddl::Action * action_obj = dynamic_cast<parser::pddl::Action *>(domain_.actions[i]);
+  for (unsigned i = 0; i < domain_->actions.size(); i++) {
+    bool is_action = dynamic_cast<parser::pddl::TemporalAction *>(domain_->actions[i]) == nullptr;
+    parser::pddl::Action * action_obj = dynamic_cast<parser::pddl::Action *>(domain_->actions[i]);
     if (is_action) {
-      ret.push_back(domain_.actions[i]->name);
+      ret.push_back(domain_->actions[i]->name);
     }
   }
   return ret;
@@ -170,9 +172,9 @@ DomainExpert::getAction(const std::string & action)
   bool found = false;
   unsigned i = 0;
 
-  while (i < domain_.actions.size() && !found) {
-    bool is_action = dynamic_cast<parser::pddl::TemporalAction *>(domain_.actions[i]) == nullptr;
-    parser::pddl::Action * action_obj = dynamic_cast<parser::pddl::Action *>(domain_.actions[i]);
+  while (i < domain_->actions.size() && !found) {
+    bool is_action = dynamic_cast<parser::pddl::TemporalAction *>(domain_->actions[i]) == nullptr;
+    parser::pddl::Action * action_obj = dynamic_cast<parser::pddl::Action *>(domain_->actions[i]);
 
     if (is_action && action_obj->name == action_search) {
       found = true;
@@ -182,8 +184,8 @@ DomainExpert::getAction(const std::string & action)
       for (unsigned j = 0; j < action_obj->params.size(); j++) {
         Param param;
         param.name = "?" + std::to_string(j);
-        param.type = domain_.types[action_obj->params[j]]->name;
-        domain_.types[action_obj->params[j]]->getSubTypesNames(param.subTypes);
+        param.type = domain_->types[action_obj->params[j]]->name;
+        domain_->types[action_obj->params[j]]->getSubTypesNames(param.subTypes);
         ret.parameters.push_back(param);
       }
 
@@ -192,7 +194,7 @@ DomainExpert::getAction(const std::string & action)
         std::stringstream pre_stream;
         action_obj->pre->PDDLPrint(
           pre_stream, 0,
-          parser::pddl::TokenStruct<std::string>(), domain_);
+          parser::pddl::TokenStruct<std::string>(), *domain_);
 
         ret.preconditions.fromString(pre_stream.str());
       }
@@ -202,7 +204,7 @@ DomainExpert::getAction(const std::string & action)
         std::stringstream effects_stream;
         action_obj->eff->PDDLPrint(
           effects_stream, 0,
-          parser::pddl::TokenStruct<std::string>(), domain_);
+          parser::pddl::TokenStruct<std::string>(), *domain_);
 
         ret.effects.fromString(effects_stream.str());
       }
@@ -221,13 +223,13 @@ std::vector<std::string>
 DomainExpert::getDurativeActions()
 {
   std::vector<std::string> ret;
-  for (unsigned i = 0; i < domain_.actions.size(); i++) {
+  for (unsigned i = 0; i < domain_->actions.size(); i++) {
     bool is_durative_action =
-      dynamic_cast<parser::pddl::TemporalAction *>(domain_.actions[i]) != nullptr;
+      dynamic_cast<parser::pddl::TemporalAction *>(domain_->actions[i]) != nullptr;
     parser::pddl::TemporalAction * action_obj =
-      dynamic_cast<parser::pddl::TemporalAction *>(domain_.actions[i]);
+      dynamic_cast<parser::pddl::TemporalAction *>(domain_->actions[i]);
     if (is_durative_action) {
-      ret.push_back(domain_.actions[i]->name);
+      ret.push_back(domain_->actions[i]->name);
     }
   }
   return ret;
@@ -245,11 +247,11 @@ DomainExpert::getDurativeAction(const std::string & action)
   bool found = false;
   unsigned i = 0;
 
-  while (i < domain_.actions.size() && !found) {
+  while (i < domain_->actions.size() && !found) {
     bool is_durative_action =
-      dynamic_cast<parser::pddl::TemporalAction *>(domain_.actions[i]) != nullptr;
+      dynamic_cast<parser::pddl::TemporalAction *>(domain_->actions[i]) != nullptr;
     parser::pddl::TemporalAction * action_obj =
-      dynamic_cast<parser::pddl::TemporalAction *>(domain_.actions[i]);
+      dynamic_cast<parser::pddl::TemporalAction *>(domain_->actions[i]);
 
     if (is_durative_action && action_obj->name == action_search) {
       found = true;
@@ -259,8 +261,8 @@ DomainExpert::getDurativeAction(const std::string & action)
       for (unsigned j = 0; j < action_obj->params.size(); j++) {
         Param param;
         param.name = "?" + std::to_string(j);
-        param.type = domain_.types[action_obj->params[j]]->name;
-        domain_.types[action_obj->params[j]]->getSubTypesNames(param.subTypes);
+        param.type = domain_->types[action_obj->params[j]]->name;
+        domain_->types[action_obj->params[j]]->getSubTypesNames(param.subTypes);
         ret.parameters.push_back(param);
       }
 
@@ -270,7 +272,7 @@ DomainExpert::getDurativeAction(const std::string & action)
           std::stringstream pre_stream;
           action_obj->pre->PDDLPrint(
             pre_stream, 0,
-            parser::pddl::TokenStruct<std::string>(), domain_);
+            parser::pddl::TokenStruct<std::string>(), *domain_);
           ret.at_start_requirements.fromString(pre_stream.str());
         }
       }
@@ -280,7 +282,7 @@ DomainExpert::getDurativeAction(const std::string & action)
         std::stringstream pre_stream;
         action_obj->pre_o->PDDLPrint(
           pre_stream, 0,
-          parser::pddl::TokenStruct<std::string>(), domain_);
+          parser::pddl::TokenStruct<std::string>(), *domain_);
 
         ret.over_all_requirements.fromString(pre_stream.str());
       }
@@ -290,7 +292,7 @@ DomainExpert::getDurativeAction(const std::string & action)
         std::stringstream pre_stream;
         action_obj->pre_e->PDDLPrint(
           pre_stream, 0,
-          parser::pddl::TokenStruct<std::string>(), domain_);
+          parser::pddl::TokenStruct<std::string>(), *domain_);
 
         ret.at_end_requirements.fromString(pre_stream.str());
       }
@@ -300,7 +302,7 @@ DomainExpert::getDurativeAction(const std::string & action)
         std::stringstream effects_stream;
         action_obj->eff->PDDLPrint(
           effects_stream, 0,
-          parser::pddl::TokenStruct<std::string>(), domain_);
+          parser::pddl::TokenStruct<std::string>(), *domain_);
 
         ret.at_start_effects.fromString(effects_stream.str());
       }
@@ -310,7 +312,7 @@ DomainExpert::getDurativeAction(const std::string & action)
         std::stringstream effects_stream;
         action_obj->eff_e->PDDLPrint(
           effects_stream, 0,
-          parser::pddl::TokenStruct<std::string>(), domain_);
+          parser::pddl::TokenStruct<std::string>(), *domain_);
 
         ret.at_end_effects.fromString(effects_stream.str());
       }
@@ -328,9 +330,7 @@ DomainExpert::getDurativeAction(const std::string & action)
 std::string
 DomainExpert::getDomain()
 {
-  std::ostringstream stream;
-  stream << domain_;
-  return stream.str();
+  return domains_.get_joint_domain();
 }
 
 }  // namespace plansys2

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertNode.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertNode.cpp
@@ -18,26 +18,9 @@
 #include <memory>
 #include <vector>
 
+#include "plansys2_core/Utils.hpp"
+
 #include "lifecycle_msgs/msg/state.hpp"
-
-std::vector<std::string> tokenize(const std::string & string, const std::string & delim)
-{
-  std::string::size_type lastPos = 0, pos = string.find_first_of(delim, lastPos);
-  std::vector<std::string> tokens;
-
-  while (lastPos != std::string::npos) {
-    if (pos != lastPos) {
-      tokens.push_back(string.substr(lastPos, pos - lastPos));
-    }
-    lastPos = pos;
-    if (lastPos == std::string::npos || lastPos + 1 == string.length()) {
-      break;
-    }
-    pos = string.find_first_of(delim, ++lastPos);
-  }
-
-  return tokens;
-}
 
 namespace plansys2
 {

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainReader.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainReader.cpp
@@ -1,0 +1,251 @@
+// Copyright 2020 Intelligent Robotics Lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "plansys2_domain_expert/DomainReader.hpp"
+
+#include <string>
+#include <vector>
+#include <algorithm>
+#include <iostream>
+#include <set>
+
+#include "plansys2_core/Utils.hpp"
+
+
+namespace plansys2
+{
+
+DomainReader::DomainReader()
+{
+}
+
+void
+DomainReader::add_domain(const std::string & domain)
+{
+  if (domain.empty()) {
+    std::cerr << "Empty domain" << std::endl;
+    return;
+  }
+
+  Domain new_domain;
+
+  std::string lc_domain = domain;
+  std::transform(
+    domain.begin(), domain.end(), lc_domain.begin(),
+    [](unsigned char c) {return std::tolower(c);});
+
+  new_domain.requirements = get_requirements(lc_domain);
+  new_domain.types = get_types(lc_domain);
+  new_domain.predicates = get_predicates(lc_domain);
+  new_domain.functions = get_functions(lc_domain);
+  new_domain.actions = get_actions(lc_domain);
+
+  domains_.push_back(new_domain);
+}
+
+std::string
+DomainReader::get_joint_domain() const
+{
+  std::string ret = "(define (domain plansys2)\n";
+
+  ret += "(:requirements ";
+
+  std::set<std::string> reqs_set;
+  for (auto & domain : domains_) {
+    std::vector<std::string> reqs = tokenize(domain.requirements, " ");
+    reqs_set.insert(reqs.begin(), reqs.end());
+  }
+  for (auto & req : reqs_set) {
+    ret += req + " ";
+  }
+  ret += ")\n\n";
+
+  ret += "(:types\n";
+  for (auto & domain : domains_) {
+    ret += domain.types + "\n";
+  }
+  ret += ")\n\n";
+
+  ret += "(:predicates\n";
+  std::set<std::string> preds_set;
+  for (auto & domain : domains_) {
+    std::vector<std::string> preds = tokenize(domain.predicates, "\n");
+    preds_set.insert(preds.begin(), preds.end());
+  }
+  for (auto & pred : preds_set) {
+    ret += pred + "\n";
+  }
+  ret += ")\n\n";
+
+  ret += "(:functions\n";
+  for (auto & domain : domains_) {
+    ret += domain.functions + "\n";
+  }
+  ret += ")\n\n";
+
+  for (auto & domain : domains_) {
+    for (auto & action : domain.actions) {
+      ret += action + "\n";
+    }
+  }
+
+  ret += ")\n";
+
+  return ret;
+}
+
+int
+DomainReader::get_end_block(const std::string & domain, std::size_t init_pos)
+{
+  std::size_t domain_length = domain.length();
+
+  auto end_pos = init_pos;
+  int p_counter = 1;
+  while (end_pos < domain_length && p_counter > 0) {
+    if (domain[end_pos] == '(') {
+      p_counter++;
+    } else if (domain[end_pos] == ')') {
+      p_counter--;
+    }
+
+    if (p_counter > 0) {
+      end_pos++;
+    }
+  }
+
+  if (p_counter == 0) {
+    return end_pos;
+  } else {
+    return -1;
+  }
+}
+
+std::string
+DomainReader::get_requirements(std::string & domain)
+{
+  const std::string pattern(":requirements");
+
+  std::size_t init_pos = domain.find(pattern);
+  if (init_pos == std::string::npos) {
+    return "";
+  }
+  init_pos += pattern.length();
+
+  auto end_pos = get_end_block(domain, init_pos);
+
+  if (end_pos >= 0) {
+    auto ret = domain.substr(init_pos, end_pos - init_pos);
+
+    // We remove the requirements part for not interfering with next analysis
+    domain.replace(init_pos, end_pos - init_pos, "");
+
+    return ret;
+  } else {
+    return "";
+  }
+}
+
+std::string
+DomainReader::get_types(const std::string & domain)
+{
+  const std::string pattern(":types");
+
+  std::size_t init_pos = domain.find(pattern);
+  if (init_pos == std::string::npos) {
+    return "";
+  }
+  init_pos += pattern.length();
+
+  auto end_pos = get_end_block(domain, init_pos);
+
+  if (end_pos >= 0) {
+    return domain.substr(init_pos, end_pos - init_pos);
+  } else {
+    return "";
+  }
+}
+
+std::string
+DomainReader::get_predicates(const std::string & domain)
+{
+  const std::string pattern(":predicates");
+
+  std::size_t init_pos = domain.find(pattern);
+  if (init_pos == std::string::npos) {
+    return "";
+  }
+  init_pos += pattern.length();
+
+  auto end_pos = get_end_block(domain, init_pos);
+
+  if (end_pos >= 0) {
+    return domain.substr(init_pos, end_pos - init_pos);
+  } else {
+    return "";
+  }
+}
+
+std::string
+DomainReader::get_functions(const std::string & domain)
+{
+  const std::string pattern(":functions");
+
+  std::size_t init_pos = domain.find(pattern);
+  if (init_pos == std::string::npos) {
+    return "";
+  }
+  init_pos += pattern.length();
+
+  auto end_pos = get_end_block(domain, init_pos);
+
+  if (end_pos >= 0) {
+    return domain.substr(init_pos, end_pos - init_pos);
+  } else {
+    return "";
+  }
+}
+
+std::vector<std::string>
+DomainReader::get_actions(const std::string & domain)
+{
+  std::vector<std::string> ret;
+
+  const std::string da_pattern(":durative-action");
+  const std::string a_pattern(":action");
+
+  auto ldomain = domain;
+
+  size_t pos = std::string::npos;
+  do {
+    std::size_t da_pos = ldomain.find(da_pattern);
+    std::size_t a_pos = ldomain.find(a_pattern);
+
+    pos = std::min(da_pos, a_pos);
+
+    if (pos != std::string::npos) {
+      auto end_pos = get_end_block(ldomain, pos + 1);
+
+      if (end_pos == -1) {
+        break;
+      }
+
+      ret.push_back(ldomain.substr(pos - 1, end_pos - pos + 2));
+      ldomain = ldomain.substr(end_pos + 1);
+    }
+  } while (!ldomain.empty() && pos != std::string::npos);
+
+  return ret;
+}
+
+}  // namespace plansys2

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainReader.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainReader.cpp
@@ -240,7 +240,7 @@ DomainReader::get_actions(const std::string & domain)
         break;
       }
 
-      ret.push_back(ldomain.substr(pos - 1, end_pos - pos + 2));
+      ret.push_back("(" + ldomain.substr(pos, end_pos - pos + 1));
       ldomain = ldomain.substr(end_pos + 1);
     }
   } while (!ldomain.empty() && pos != std::string::npos);

--- a/plansys2_domain_expert/test/pddl/domain_combined_processed.pddl
+++ b/plansys2_domain_expert/test/pddl/domain_combined_processed.pddl
@@ -1,29 +1,39 @@
 (define (domain plansys2)
-(:requirements :strips :typing :adl :fluents :durative-actions)
+(:requirements :adl :durative-actions :fluents :strips :typing )
 
-;; Types ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (:types
+
 person  - object 
 message - object
 robot   - object
 room    - object
 teleporter_room - room
-);; end Types ;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; Predicates ;;;;;;;;;;;;;;;;;;;;;;;;;
+
+robot
+pickable_object
+room
+
+)
+
 (:predicates
-
-(robot_talk ?r - robot ?m - message ?p - person)
-(robot_near_person ?r - robot ?p - person)
-(robot_at ?r - robot ?ro - room)
+(object_at_robot ?o - pickable_object ?r - robot)
+(object_at_room ?o - pickable_object ?ro - room)
 (person_at ?p - person ?ro - room)
+(robot_at ?r - robot ?ro - room)
+(robot_near_person ?r - robot ?p - person)
+(robot_talk ?r - robot ?m - message ?p - person)
+)
 
-);; end Predicates ;;;;;;;;;;;;;;;;;;;;
-;; Functions ;;;;;;;;;;;;;;;;;;;;;;;;;
 (:functions
+
     (teleportation_time ?from - teleporter_room ?to - room)
-);; end Functions ;;;;;;;;;;;;;;;;;;;;
-;; Actions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+
+
+
+)
+
 (:durative-action move
     :parameters (?r - robot ?r1 ?r2 - room)
     :duration ( = ?duration 5)
@@ -34,7 +44,6 @@ teleporter_room - room
         (at end(robot_at ?r ?r2))
     )
 )
-
 (:durative-action talk
     :parameters (?r - robot ?from ?p - person ?m - message)
     :duration ( = ?duration 5)
@@ -45,7 +54,6 @@ teleporter_room - room
         (at end(robot_talk ?r ?m ?p))
     )
 )
-
 (:durative-action approach
     :parameters (?r - robot ?ro - room ?p - person)
     :duration ( = ?duration 5)
@@ -57,7 +65,6 @@ teleporter_room - room
         (at end(robot_near_person ?r ?p))
     )
 )
-
 (:action move_person
     :parameters (?p - person ?r1 ?r2 - room)
     :precondition (and 
@@ -68,6 +75,28 @@ teleporter_room - room
         (not(person_at ?p ?r1))
     )
 )
-
-
-);; end Domain ;;;;;;;;;;;;;;;;;;;;;;;;
+(:durative-action pick_object
+    :parameters (?r - robot ?ro - room ?o - pickable_object)
+    :duration ( = ?duration 5)
+    :condition (and
+        (at start(object_at_room ?o ?ro))
+        (at start(robot_at ?r ?ro))
+        )
+    :effect (and
+        (at start(not(object_at_room ?o ?ro)))
+        (at end(object_at_robot ?o ?r))
+    )
+)
+(:durative-action place_object
+    :parameters (?r - robot ?ro - room ?o - pickable_object)
+    :duration ( = ?duration 5)
+    :condition (and
+        (at start(object_at_robot ?o ?r))
+        (at start(robot_at ?r ?ro))
+        )
+    :effect (and
+        (at start(not(object_at_robot ?o ?r)))
+        (at end(object_at_room ?o ?ro))
+    )
+)
+)

--- a/plansys2_domain_expert/test/pddl/domain_simple_ext.pddl
+++ b/plansys2_domain_expert/test/pddl/domain_simple_ext.pddl
@@ -1,4 +1,4 @@
-(define (domain simple)
+(define (domain plansys2)
 (:requirements :strips :typing :adl :fluents :durative-actions)
 
 ;; Types ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/plansys2_domain_expert/test/pddl/domain_simple_processed.pddl
+++ b/plansys2_domain_expert/test/pddl/domain_simple_processed.pddl
@@ -1,29 +1,29 @@
 (define (domain plansys2)
-(:requirements :strips :typing :adl :fluents :durative-actions)
+(:requirements :adl :durative-actions :fluents :strips :typing )
 
-;; Types ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (:types
+
 person  - object 
 message - object
 robot   - object
 room    - object
 teleporter_room - room
-);; end Types ;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; Predicates ;;;;;;;;;;;;;;;;;;;;;;;;;
+)
+
 (:predicates
-
-(robot_talk ?r - robot ?m - message ?p - person)
-(robot_near_person ?r - robot ?p - person)
-(robot_at ?r - robot ?ro - room)
 (person_at ?p - person ?ro - room)
+(robot_at ?r - robot ?ro - room)
+(robot_near_person ?r - robot ?p - person)
+(robot_talk ?r - robot ?m - message ?p - person)
+)
 
-);; end Predicates ;;;;;;;;;;;;;;;;;;;;
-;; Functions ;;;;;;;;;;;;;;;;;;;;;;;;;
 (:functions
+
     (teleportation_time ?from - teleporter_room ?to - room)
-);; end Functions ;;;;;;;;;;;;;;;;;;;;
-;; Actions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+)
+
 (:durative-action move
     :parameters (?r - robot ?r1 ?r2 - room)
     :duration ( = ?duration 5)
@@ -34,7 +34,6 @@ teleporter_room - room
         (at end(robot_at ?r ?r2))
     )
 )
-
 (:durative-action talk
     :parameters (?r - robot ?from ?p - person ?m - message)
     :duration ( = ?duration 5)
@@ -45,7 +44,6 @@ teleporter_room - room
         (at end(robot_talk ?r ?m ?p))
     )
 )
-
 (:durative-action approach
     :parameters (?r - robot ?ro - room ?p - person)
     :duration ( = ?duration 5)
@@ -57,7 +55,6 @@ teleporter_room - room
         (at end(robot_near_person ?r ?p))
     )
 )
-
 (:action move_person
     :parameters (?p - person ?r1 ?r2 - room)
     :precondition (and 
@@ -68,6 +65,4 @@ teleporter_room - room
         (not(person_at ?p ?r1))
     )
 )
-
-
-);; end Domain ;;;;;;;;;;;;;;;;;;;;;;;;
+)

--- a/plansys2_domain_expert/test/pddl/factory.pddl
+++ b/plansys2_domain_expert/test/pddl/factory.pddl
@@ -1,0 +1,83 @@
+( define ( domain factory )
+( :requirements :strips :adl :typing :durative-actions :fluents )
+( :types
+	robot - object
+	zone - object
+	piece - object
+	car - object
+)
+( :predicates
+	( robot_available ?robot0 - robot )
+	( robot_at ?robot0 - robot ?zone1 - zone )
+	( piece_at ?piece0 - piece ?zone1 - zone )
+	( piece_is_wheel ?piece0 - piece )
+	( piece_is_body_car ?piece0 - piece )
+	( piece_is_steering_wheel ?piece0 - piece )
+	( piece_not_used ?piece0 - piece )
+	( is_assembly_zone ?zone0 - zone )
+	( car_assembled ?car0 - car )
+)
+( :durative-action move
+  :parameters ( ?robot0 - robot ?zone1 - zone ?zone2 - zone )
+  :duration ( = ?duration 5 )
+  :condition
+	( and
+		( at start ( robot_available ?robot0 ) )
+		( at start ( robot_at ?robot0 ?zone1 ) )
+	)
+  :effect
+	( and
+		( at start ( not ( robot_at ?robot0 ?zone1 ) ) )
+		( at start ( not ( robot_available ?robot0 ) ) )
+		( at end ( robot_at ?robot0 ?zone2 ) )
+		( at end ( robot_available ?robot0 ) )
+	)
+)
+( :durative-action transport
+  :parameters ( ?robot0 - robot ?piece1 - piece ?zone2 - zone ?zone3 - zone )
+  :duration ( = ?duration 5 )
+  :condition
+	( and
+		( at start ( robot_available ?robot0 ) )
+		( at start ( robot_at ?robot0 ?zone2 ) )
+		( at start ( piece_at ?piece1 ?zone2 ) )
+	)
+  :effect
+	( and
+		( at start ( not ( robot_at ?robot0 ?zone2 ) ) )
+		( at start ( not ( piece_at ?piece1 ?zone2 ) ) )
+		( at start ( not ( robot_available ?robot0 ) ) )
+		( at end ( robot_at ?robot0 ?zone3 ) )
+		( at end ( piece_at ?piece1 ?zone3 ) )
+		( at end ( robot_available ?robot0 ) )
+	)
+)
+( :durative-action assemble
+  :parameters ( ?robot0 - robot ?zone1 - zone ?piece2 - piece ?piece3 - piece ?piece4 - piece ?car5 - car )
+  :duration ( = ?duration 5 )
+  :condition
+	( and
+		( at start ( robot_available ?robot0 ) )
+		( at start ( is_assembly_zone ?zone1 ) )
+		( at start ( robot_at ?robot0 ?zone1 ) )
+		( at start ( piece_at ?piece2 ?zone1 ) )
+		( at start ( piece_at ?piece3 ?zone1 ) )
+		( at start ( piece_at ?piece4 ?zone1 ) )
+		( at start ( piece_not_used ?piece2 ) )
+		( at start ( piece_not_used ?piece3 ) )
+		( at start ( piece_not_used ?piece4 ) )
+		( at start ( piece_is_wheel ?piece2 ) )
+		( at start ( piece_is_body_car ?piece3 ) )
+		( at start ( piece_is_steering_wheel ?piece4 ) )
+	)
+  :effect
+	( and
+		( at start ( not ( piece_not_used ?piece2 ) ) )
+		( at start ( not ( piece_not_used ?piece3 ) ) )
+		( at start ( not ( piece_not_used ?piece4 ) ) )
+		( at start ( not ( robot_available ?robot0 ) ) )
+		( at end ( car_assembled ?car5 ) )
+		( at end ( robot_available ?robot0 ) )
+	)
+)
+)

--- a/plansys2_domain_expert/test/pddl/factory_processed.pddl
+++ b/plansys2_domain_expert/test/pddl/factory_processed.pddl
@@ -1,0 +1,92 @@
+(define (domain plansys2)
+(:requirements :adl :durative-actions :fluents :strips :typing )
+
+(:types
+
+	robot - object
+	zone - object
+	piece - object
+	car - object
+
+)
+
+(:predicates
+	( car_assembled ?car0 - car )
+	( is_assembly_zone ?zone0 - zone )
+	( piece_at ?piece0 - piece ?zone1 - zone )
+	( piece_is_body_car ?piece0 - piece )
+	( piece_is_steering_wheel ?piece0 - piece )
+	( piece_is_wheel ?piece0 - piece )
+	( piece_not_used ?piece0 - piece )
+	( robot_at ?robot0 - robot ?zone1 - zone )
+	( robot_available ?robot0 - robot )
+)
+
+(:functions
+
+)
+
+(:durative-action move
+  :parameters ( ?robot0 - robot ?zone1 - zone ?zone2 - zone )
+  :duration ( = ?duration 5 )
+  :condition
+	( and
+		( at start ( robot_available ?robot0 ) )
+		( at start ( robot_at ?robot0 ?zone1 ) )
+	)
+  :effect
+	( and
+		( at start ( not ( robot_at ?robot0 ?zone1 ) ) )
+		( at start ( not ( robot_available ?robot0 ) ) )
+		( at end ( robot_at ?robot0 ?zone2 ) )
+		( at end ( robot_available ?robot0 ) )
+	)
+)
+(:durative-action transport
+  :parameters ( ?robot0 - robot ?piece1 - piece ?zone2 - zone ?zone3 - zone )
+  :duration ( = ?duration 5 )
+  :condition
+	( and
+		( at start ( robot_available ?robot0 ) )
+		( at start ( robot_at ?robot0 ?zone2 ) )
+		( at start ( piece_at ?piece1 ?zone2 ) )
+	)
+  :effect
+	( and
+		( at start ( not ( robot_at ?robot0 ?zone2 ) ) )
+		( at start ( not ( piece_at ?piece1 ?zone2 ) ) )
+		( at start ( not ( robot_available ?robot0 ) ) )
+		( at end ( robot_at ?robot0 ?zone3 ) )
+		( at end ( piece_at ?piece1 ?zone3 ) )
+		( at end ( robot_available ?robot0 ) )
+	)
+)
+(:durative-action assemble
+  :parameters ( ?robot0 - robot ?zone1 - zone ?piece2 - piece ?piece3 - piece ?piece4 - piece ?car5 - car )
+  :duration ( = ?duration 5 )
+  :condition
+	( and
+		( at start ( robot_available ?robot0 ) )
+		( at start ( is_assembly_zone ?zone1 ) )
+		( at start ( robot_at ?robot0 ?zone1 ) )
+		( at start ( piece_at ?piece2 ?zone1 ) )
+		( at start ( piece_at ?piece3 ?zone1 ) )
+		( at start ( piece_at ?piece4 ?zone1 ) )
+		( at start ( piece_not_used ?piece2 ) )
+		( at start ( piece_not_used ?piece3 ) )
+		( at start ( piece_not_used ?piece4 ) )
+		( at start ( piece_is_wheel ?piece2 ) )
+		( at start ( piece_is_body_car ?piece3 ) )
+		( at start ( piece_is_steering_wheel ?piece4 ) )
+	)
+  :effect
+	( and
+		( at start ( not ( piece_not_used ?piece2 ) ) )
+		( at start ( not ( piece_not_used ?piece3 ) ) )
+		( at start ( not ( piece_not_used ?piece4 ) ) )
+		( at start ( not ( robot_available ?robot0 ) ) )
+		( at end ( car_assembled ?car5 ) )
+		( at end ( robot_available ?robot0 ) )
+	)
+)
+)

--- a/plansys2_domain_expert/test/pddl/problem_simple_1.pddl
+++ b/plansys2_domain_expert/test/pddl/problem_simple_1.pddl
@@ -1,5 +1,5 @@
-(define (problem simple_1)
-  (:domain simple)
+(define (problem plansys2_1)
+  (:domain plansys2)
   (:objects
     leia - robot
     Jack - person

--- a/plansys2_domain_expert/test/unit/CMakeLists.txt
+++ b/plansys2_domain_expert/test/unit/CMakeLists.txt
@@ -1,5 +1,11 @@
 ament_add_gtest(domain_expert_test domain_expert_test.cpp)
 target_link_libraries(domain_expert_test ${PROJECT_NAME})
 
+ament_add_gtest(domain_expert_node_test domain_expert_node_test.cpp)
+target_link_libraries(domain_expert_node_test ${PROJECT_NAME})
+
+ament_add_gtest(domain_reader_test domain_reader_test.cpp)
+target_link_libraries(domain_reader_test ${PROJECT_NAME})
+
 ament_add_gtest(types_test types_test.cpp)
 target_link_libraries(types_test ${PROJECT_NAME})

--- a/plansys2_domain_expert/test/unit/domain_expert_node_test.cpp
+++ b/plansys2_domain_expert/test/unit/domain_expert_node_test.cpp
@@ -1,0 +1,105 @@
+// Copyright 2019 Intelligent Robotics Lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <vector>
+#include <regex>
+#include <iostream>
+#include <memory>
+
+#include "ament_index_cpp/get_package_share_directory.hpp"
+
+#include "gtest/gtest.h"
+#include "plansys2_domain_expert/DomainExpertNode.hpp"
+#include "plansys2_domain_expert/DomainExpertClient.hpp"
+
+#include "lifecycle_msgs/msg/state.hpp"
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+
+TEST(domain_expert, lifecycle)
+{
+  auto test_node = rclcpp::Node::make_shared("get_action_from_string");
+  auto domain_node = std::make_shared<plansys2::DomainExpertNode>();
+  auto domain_client = std::make_shared<plansys2::DomainExpertClient>(test_node);
+
+  std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_domain_expert");
+
+  domain_node->set_parameter({"model_file", pkgpath + "/pddl/domain_simple.pddl"});
+  rclcpp::executors::MultiThreadedExecutor exe(rclcpp::executor::ExecutorArgs(), 8);
+
+  exe.add_node(domain_node->get_node_base_interface());
+
+  bool finish = false;
+  std::thread t([&]() {
+      while (!finish) {exe.spin_some();}
+    });
+
+  domain_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = test_node->now();
+    while ((test_node->now() - start).seconds() < 0.5) {
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(
+    domain_node->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  domain_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = test_node->now();
+    while ((test_node->now() - start).seconds() < 0.5) {
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(
+    domain_node->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  auto domain_str = domain_client->getDomain();
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = test_node->now();
+    while ((test_node->now() - start).seconds() < 0.5) {
+      rate.sleep();
+    }
+  }
+
+  std::ifstream domain_ifs_p(pkgpath + "/pddl/domain_simple_processed.pddl");
+  std::string domain_str_p((
+      std::istreambuf_iterator<char>(domain_ifs_p)),
+    std::istreambuf_iterator<char>());
+
+  ASSERT_EQ(domain_str, domain_str_p);
+
+  finish = true;
+  t.join();
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+
+  return RUN_ALL_TESTS();
+}

--- a/plansys2_domain_expert/test/unit/domain_expert_test.cpp
+++ b/plansys2_domain_expert/test/unit/domain_expert_test.cpp
@@ -71,8 +71,26 @@ TEST(domain_expert, get_domain)
     std::istreambuf_iterator<char>());
 
   plansys2::DomainExpert domain_expert(domain_str);
-  ASSERT_EQ(domain_expert.getDomain(), domain_str_p);  
+  ASSERT_EQ(domain_expert.getDomain(), domain_str_p);
 }
+
+TEST(domain_expert, get_domain2)
+{
+  std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_domain_expert");
+  std::ifstream domain_ifs(pkgpath + "/pddl/factory.pddl");
+  std::string domain_str((
+      std::istreambuf_iterator<char>(domain_ifs)),
+    std::istreambuf_iterator<char>());
+
+  std::ifstream domain_ifs_p(pkgpath + "/pddl/factory_processed.pddl");
+  std::string domain_str_p((
+      std::istreambuf_iterator<char>(domain_ifs_p)),
+    std::istreambuf_iterator<char>());
+
+  plansys2::DomainExpert domain_expert(domain_str);
+  ASSERT_EQ(domain_expert.getDomain(), domain_str_p);
+}
+
 
 TEST(domain_expert, get_types)
 {

--- a/plansys2_domain_expert/test/unit/domain_expert_test.cpp
+++ b/plansys2_domain_expert/test/unit/domain_expert_test.cpp
@@ -57,6 +57,22 @@ TEST(domain_expert, functions)
   ASSERT_EQ(getReducedString(my_string), "((and))");
 }
 
+TEST(domain_expert, get_domain)
+{
+  std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_domain_expert");
+  std::ifstream domain_ifs(pkgpath + "/pddl/domain_simple.pddl");
+  std::string domain_str((
+      std::istreambuf_iterator<char>(domain_ifs)),
+    std::istreambuf_iterator<char>());
+
+  std::ifstream domain_ifs_p(pkgpath + "/pddl/domain_simple_processed.pddl");
+  std::string domain_str_p((
+      std::istreambuf_iterator<char>(domain_ifs_p)),
+    std::istreambuf_iterator<char>());
+
+  plansys2::DomainExpert domain_expert(domain_str);
+  ASSERT_EQ(domain_expert.getDomain(), domain_str_p);  
+}
 
 TEST(domain_expert, get_types)
 {
@@ -86,8 +102,8 @@ TEST(domain_expert, get_predicates)
   plansys2::DomainExpert domain_expert(domain_str);
 
   std::vector<std::string> predicates = domain_expert.getPredicates();
-  std::vector<std::string> predicates_types {"robot_talk", "robot_near_person", "robot_at",
-    "person_at"};
+  std::vector<std::string> predicates_types {"person_at", "robot_at", "robot_near_person",
+    "robot_talk"};
 
   ASSERT_EQ(predicates, predicates_types);
 }
@@ -214,8 +230,8 @@ TEST(domain_expert, multidomain_get_types)
   ASSERT_EQ(types, test_types);
 
   std::vector<std::string> predicates = domain_expert->getPredicates();
-  std::vector<std::string> test_predicates {"robot_talk", "robot_near_person",
-    "robot_at", "person_at", "robot_at", "object_at_robot", "object_at_room"};
+  std::vector<std::string> test_predicates {"object_at_robot", "object_at_room", "person_at",
+    "robot_at", "robot_near_person", "robot_talk"};
 
   ASSERT_EQ(predicates, test_predicates);
 

--- a/plansys2_domain_expert/test/unit/domain_reader_test.cpp
+++ b/plansys2_domain_expert/test/unit/domain_reader_test.cpp
@@ -1,0 +1,297 @@
+// Copyright 2019 Intelligent Robotics Lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <fstream>
+#include <vector>
+
+#include "ament_index_cpp/get_package_share_directory.hpp"
+
+#include "gtest/gtest.h"
+
+#include "plansys2_domain_expert/DomainReader.hpp"
+
+class DomainReaderTest : public plansys2::DomainReader
+{
+public:
+  std::size_t get_end_block_test(const std::string & domain, std::size_t init_pos)
+  {
+    return get_end_block(domain, init_pos);
+  }
+
+  std::string get_requirements_test(std::string & domain)
+  {
+    return get_requirements(domain);
+  }
+
+  std::string get_types_test(const std::string & domain)
+  {
+    return get_types(domain);
+  }
+
+  std::string get_predicates_test(const std::string & domain)
+  {
+    return get_predicates(domain);
+  }
+
+  std::string get_functions_test(const std::string & domain)
+  {
+    return get_functions(domain);
+  }
+  std::vector<std::string> get_actions_test(const std::string & domain)
+  {
+    return get_actions(domain);
+  }
+
+  void add_domain_test(const std::string & domain)
+  {
+    add_domain(domain);
+  }
+
+  std::string get_joint_domain_test()
+  {
+    return get_joint_domain();
+  }
+};
+
+TEST(domain_reader, get_block)
+{
+  DomainReaderTest dr;
+
+  std::string block1 = "";
+  std::string block2 = ")";
+  std::string block3 = "\n)";
+  std::string block4 = "word)";
+  std::string block5 = "word )";
+  std::string block6 = " word )";
+  std::string block7 = " (word ) )";
+  std::string block8 = " word ) \n)";
+  std::string block9 = " ( ";
+  std::string block10 = " :strips :typing :adl :fluents :durative-actions";
+
+  ASSERT_EQ(-1, dr.get_end_block_test(block1, 0));
+  ASSERT_EQ(0, dr.get_end_block_test(block2, 0));
+  ASSERT_EQ(1, dr.get_end_block_test(block3, 0));
+  ASSERT_EQ(4, dr.get_end_block_test(block4, 0));
+  ASSERT_EQ(4, dr.get_end_block_test(block4, 1));
+  ASSERT_EQ(4, dr.get_end_block_test(block4, 2));
+  ASSERT_EQ(5, dr.get_end_block_test(block5, 0));
+  ASSERT_EQ(6, dr.get_end_block_test(block6, 0));
+  ASSERT_EQ(9, dr.get_end_block_test(block7, 0));
+  ASSERT_EQ(6, dr.get_end_block_test(block8, 0));
+  ASSERT_EQ(-1, dr.get_end_block_test(block9, 0));
+  ASSERT_EQ(-1, dr.get_end_block_test(block10, 0));
+}
+
+TEST(domain_reader, requirements)
+{
+  DomainReaderTest dr;
+
+  std::string req1_str = "(:requirements :strips :typing :adl :fluents :durative-actions)";
+  std::string req1_estr = " :strips :typing :adl :fluents :durative-actions";
+
+  std::string req2_str = "(\n:requirements :strips :typing :adl :fluents :durative-actions\n)";
+  std::string req2_estr = " :strips :typing :adl :fluents :durative-actions\n";
+
+  std::string req3_str = "(:requirements :strips :typing :adl :fluents :durative-actions\n) (\n))";
+  std::string req3_estr = " :strips :typing :adl :fluents :durative-actions\n";
+
+  std::string req4_str = "(:requirements :strips :typing :adl :fluents :durative-actions";
+  std::string req4_estr = "";
+
+  auto res1 = dr.get_requirements_test(req1_str);
+  auto res2 = dr.get_requirements_test(req2_str);
+  auto res3 = dr.get_requirements_test(req3_str);
+  auto res4 = dr.get_requirements_test(req4_str);
+
+  ASSERT_EQ(res1, req1_estr);
+  ASSERT_EQ(req1_str, "(:requirements)");
+
+  ASSERT_EQ(res2, req2_estr);
+  ASSERT_EQ(req2_str, "(\n:requirements)");
+
+  ASSERT_EQ(res3, req3_estr);
+  ASSERT_EQ(res4, req4_estr);
+}
+
+TEST(domain_reader, types)
+{
+  DomainReaderTest dr;
+
+  std::string req1_str = "(:types type1 type2)";
+  std::string req1_estr = " type1 type2";
+
+  std::string req2_str = "(:types\ntype1 type2\n)";
+  std::string req2_estr = "\ntype1 type2\n";
+
+  std::string req3_str = "(:types\ntype1\ntype2\n)";
+  std::string req3_estr = "\ntype1\ntype2\n";
+
+  std::string req4_str = "(:types\ntype1\ntype2\n) ) ";
+  std::string req4_estr = "\ntype1\ntype2\n";
+
+  std::string req5_str = "(:types\ntype1\ntype2\n";
+  std::string req5_estr = "";
+
+  auto res1 = dr.get_types_test(req1_str);
+  auto res2 = dr.get_types_test(req2_str);
+  auto res3 = dr.get_types_test(req3_str);
+  auto res4 = dr.get_types_test(req4_str);
+  auto res5 = dr.get_types_test(req5_str);
+
+  ASSERT_EQ(res1, req1_estr);
+  ASSERT_EQ(res2, req2_estr);
+  ASSERT_EQ(res3, req3_estr);
+  ASSERT_EQ(res4, req4_estr);
+  ASSERT_EQ(res5, req5_estr);
+}
+
+TEST(domain_reader, predicates)
+{
+  DomainReaderTest dr;
+
+  std::string req1_str = "(:predicates\n(robot_at leia bedroom) (person_at paco kitchen)\n)";
+  std::string req1_estr = "\n(robot_at leia bedroom) (person_at paco kitchen)\n";
+
+  std::string req2_str = "(:predicates\n(robot_at leia bedroom) (person_at paco kitchen\n";
+  std::string req2_estr = "";
+
+
+  auto res1 = dr.get_predicates_test(req1_str);
+  auto res2 = dr.get_predicates_test(req2_str);
+
+  ASSERT_EQ(res1, req1_estr);
+  ASSERT_EQ(res2, req2_estr);
+}
+
+TEST(domain_reader, functions)
+{
+  DomainReaderTest dr;
+
+  std::string req1_str =
+    "(:functions\n(=(robot_at leia bedroom) 10)\n(=(person_at paco kitchen) 30)\n)";
+  std::string req1_estr = "\n(=(robot_at leia bedroom) 10)\n(=(person_at paco kitchen) 30)\n";
+
+  std::string req2_str =
+    "(:functions\n(=(robot_at leia bedroom) 10)\n(=(person_at paco kitchen) 30\n)";
+  std::string req2_estr = "";
+
+
+  auto res1 = dr.get_functions_test(req1_str);
+  auto res2 = dr.get_functions_test(req2_str);
+
+  ASSERT_EQ(res1, req1_estr);
+  ASSERT_EQ(res2, req2_estr);
+}
+
+TEST(domain_reader, actions)
+{
+  DomainReaderTest dr;
+
+  std::string req0_str = "(:predicates\n(robot_at leia bedroom) (person_at paco kitchen)\n)";
+
+  std::string req1_str =
+    "(:action\n whatever \n)";
+  std::string req1_estr = "(:action\n whatever \n)";
+
+  std::string req2_str =
+    "\n text other (:action\n whatever \n) more text";
+  std::string req2_estr = "(:action\n whatever \n)";
+
+  std::string req3_str = std::string("((:types type1 type2)\n(:action\n   whatever\n) \n") +
+    std::string("(:durative-action\n  whatever\n)");
+  std::string req3_1_estr = "(:action\n   whatever\n)";
+  std::string req3_2_estr = "(:durative-action\n  whatever\n)";
+
+  std::string req4_str = std::string("((:types type1 type2)\n(:action\n   whatever\n) \n") +
+    std::string("(:durative-action\n  whatever\n");
+  std::string req4_1_estr = "(:action\n   whatever\n)";
+
+
+  auto res0 = dr.get_actions_test(req0_str);
+  auto res1 = dr.get_actions_test(req1_str);
+  auto res2 = dr.get_actions_test(req2_str);
+  auto res3 = dr.get_actions_test(req3_str);
+  auto res4 = dr.get_actions_test(req4_str);
+
+  ASSERT_TRUE(res0.empty());
+
+  ASSERT_FALSE(res1.empty());
+  ASSERT_EQ(res1.size(), 1u);
+  ASSERT_EQ(res1[0], req1_estr);
+
+  ASSERT_FALSE(res2.empty());
+  ASSERT_EQ(res2.size(), 1u);
+  ASSERT_EQ(res2[0], req2_estr);
+
+  ASSERT_EQ(res3.size(), 2u);
+  ASSERT_EQ(res3[0], req3_1_estr);
+  ASSERT_EQ(res3[1], req3_2_estr);
+
+  ASSERT_EQ(res4.size(), 1u);
+  ASSERT_EQ(res4[0], req4_1_estr);
+}
+
+TEST(domain_reader, add_domain)
+{
+  DomainReaderTest dr;
+
+  std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_domain_expert");
+  std::ifstream domain_ifs(pkgpath + "/pddl/domain_simple.pddl");
+  std::string domain_str((
+      std::istreambuf_iterator<char>(domain_ifs)),
+    std::istreambuf_iterator<char>());
+
+  std::ifstream domain_ifs_p(pkgpath + "/pddl/domain_simple_processed.pddl");
+  std::string domain_str_p((
+      std::istreambuf_iterator<char>(domain_ifs_p)),
+    std::istreambuf_iterator<char>());
+
+  dr.add_domain(domain_str);
+
+  ASSERT_EQ(dr.get_joint_domain_test(), domain_str_p);
+}
+
+TEST(domain_reader, add_2_domain)
+{
+  DomainReaderTest dr;
+
+  std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_domain_expert");
+  std::ifstream domain_ifs(pkgpath + "/pddl/domain_simple.pddl");
+  std::string domain_str((
+      std::istreambuf_iterator<char>(domain_ifs)),
+    std::istreambuf_iterator<char>());
+
+  std::ifstream domain_ifs_2(pkgpath + "/pddl/domain_simple_ext.pddl");
+  std::string domain_str_2((
+      std::istreambuf_iterator<char>(domain_ifs_2)),
+    std::istreambuf_iterator<char>());
+
+
+  std::ifstream domain_ifs_p(pkgpath + "/pddl/domain_combined_processed.pddl");
+  std::string domain_str_p((
+      std::istreambuf_iterator<char>(domain_ifs_p)),
+    std::istreambuf_iterator<char>());
+
+  dr.add_domain(domain_str);
+  dr.add_domain(domain_str_2);
+
+  ASSERT_EQ(dr.get_joint_domain_test(), domain_str_p);
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/plansys2_problem_expert/test/unit/problem_expert_test.cpp
+++ b/plansys2_problem_expert/test/unit/problem_expert_test.cpp
@@ -99,7 +99,7 @@ TEST(problem_expert, add_assignments)
   ASSERT_EQ(
     problem_expert.getProblem(),
     "( define ( problem problem_1 )\n"
-    "( :domain simple )\n"
+    "( :domain plansys2 )\n"
     "( :objects\n"
     "\tbedroom - room\n"
     "\tkitchen - room_with_teleporter\n"
@@ -132,7 +132,7 @@ TEST(problem_expert, add_assignments)
   ASSERT_EQ(
     problem_expert.getProblem(),
     "( define ( problem problem_1 )\n"
-    "( :domain simple )\n"
+    "( :domain plansys2 )\n"
     "( :objects\n"
     "\tbedroom - room\n"
     "\tkitchen - room_with_teleporter\n"
@@ -154,7 +154,7 @@ TEST(problem_expert, add_assignments)
   ASSERT_EQ(
     problem_expert.getProblem(),
     "( define ( problem problem_1 )\n"
-    "( :domain simple )\n"
+    "( :domain plansys2 )\n"
     "( :objects\n"
     "\tbedroom - room\n"
     "\tkitchen - room_with_teleporter\n"
@@ -438,7 +438,7 @@ TEST(problem_expert, get_probem)
 
   ASSERT_EQ(
     problem_expert.getProblem(),
-    std::string("( define ( problem problem_1 )\n( :domain simple ") +
+    std::string("( define ( problem problem_1 )\n( :domain plansys2 ") +
     std::string(")\n( :objects\n\tpaco - person\n\tr2d2 - robot\n\tbedroom kitchen - room\n)\n") +
     std::string("( :init\n\t( robot_at r2d2 bedroom )\n\t( robot_at r2d2 kitchen )\n\t( ") +
     std::string("person_at paco bedroom )\n\t( person_at paco kitchen )\n)\n( :goal\n\t( ") +


### PR DESCRIPTION
Dear all,

This is a big change, and I would like to have feedback from you @teyssieuman @mark-sentaca @jjzapf @rossj13

Issues #61 #35 #21, at least, are motivated by the limitation of how plansys2_domain_expert stores the pddl domain. That's because I wanted to manage (merge) several domains. This can be useful in an application [like this ](https://github.com/IntelligentRoboticsLabs/ros2_planning_system_examples/tree/master/plansys2_multidomain_example).

This PR contains an alternative way to solve this. With these changes, the model is not *deep* parsed, with the limitation that you found. Now, the domains are merged, respecting the original pddl content.

I hope you find it interesting. Please, try this branch to see if it solves the limitation that you found.

Best

