### PR TITLE
Namespaced action_hub

### DIFF
--- a/plansys2_executor/src/plansys2_executor/ActionExecutor.cpp
+++ b/plansys2_executor/src/plansys2_executor/ActionExecutor.cpp
@@ -32,9 +32,9 @@ ActionExecutor::ActionExecutor(
 : state_(IDLE), node_(node)
 {
   action_hub_pub_ = node_->create_publisher<plansys2_msgs::msg::ActionExecution>(
-    "/actions_hub", rclcpp::QoS(100).reliable());
+    "actions_hub", rclcpp::QoS(100).reliable());
   action_hub_sub_ = node_->create_subscription<plansys2_msgs::msg::ActionExecution>(
-    "/actions_hub", rclcpp::QoS(100).reliable(),
+    "actions_hub", rclcpp::QoS(100).reliable(),
     std::bind(&ActionExecutor::action_hub_callback, this, _1));
 
   state_time_ = node_->now();

--- a/plansys2_executor/src/plansys2_executor/ActionExecutorClient.cpp
+++ b/plansys2_executor/src/plansys2_executor/ActionExecutorClient.cpp
@@ -47,9 +47,9 @@ ActionExecutorClient::on_configure(const rclcpp_lifecycle::State & state)
     "specialized_arguments", specialized_arguments_, std::vector<std::string>({}));
 
   action_hub_pub_ = create_publisher<plansys2_msgs::msg::ActionExecution>(
-    "/actions_hub", rclcpp::QoS(100).reliable());
+    "actions_hub", rclcpp::QoS(100).reliable());
   action_hub_sub_ = create_subscription<plansys2_msgs::msg::ActionExecution>(
-    "/actions_hub", rclcpp::QoS(100).reliable(),
+    "actions_hub", rclcpp::QoS(100).reliable(),
     std::bind(&ActionExecutorClient::action_hub_callback, this, _1));
 
   action_hub_pub_->on_activate();

--- a/plansys2_executor/test/unit/executor_test.cpp
+++ b/plansys2_executor/test/unit/executor_test.cpp
@@ -204,7 +204,7 @@ TEST(problem_expert, action_executor_client)
   std::vector<plansys2_msgs::msg::ActionExecution> history_msgs;
   bool confirmed = false;
   auto actions_sub = aux_node->create_subscription<plansys2_msgs::msg::ActionExecution>(
-    "/actions_hub",
+    "actions_hub",
     rclcpp::QoS(100).reliable(), [&](plansys2_msgs::msg::ActionExecution::UniquePtr msg) {
       history_msgs.push_back(*msg);
     });


### PR DESCRIPTION
Hi,

The executor used the `/actions_hub` topic to coordinate the execution of the actions. This topic also must be namespace when using a namespace. In another case, we can have conflicts if using several plansys2 instances.

Signed-off-by: Francisco Martin Rico <fmrico@gmail.com>