### PR TITLE
Ignore comments on block end search

### DIFF
--- a/plansys2_core/include/plansys2_core/Utils.hpp
+++ b/plansys2_core/include/plansys2_core/Utils.hpp
@@ -23,6 +23,27 @@ namespace plansys2
 
 std::vector<std::string> tokenize(const std::string & string, const std::string & delim);
 
+/**
+ * @brief get a substring without empty lines
+ *
+ * @param string original string
+ * @param init_pos first character in the original string
+ * @param end_pos last character in the original string
+ * @return a substring without empty lines
+ */
+std::string substr_without_empty_lines(
+  std::string string,
+  std::size_t init_pos,
+  std::size_t end_pos);
+
+/**
+ * @brief remove the comments on a pddl string
+ *
+ * @param pddl a pddl string
+ * @return a pddl string without comments
+ */
+std::string remove_comments(const std::string & pddl);
+
 }  // namespace plansys2
 
 #endif  // PLANSYS2_CORE__UTILS_HPP_

--- a/plansys2_core/src/plansys2_core/Utils.cpp
+++ b/plansys2_core/src/plansys2_core/Utils.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <string>
+#include <sstream>
 #include <vector>
 
 #include "plansys2_core/Utils.hpp"
@@ -39,4 +40,51 @@ std::vector<std::string> tokenize(const std::string & string, const std::string 
   return tokens;
 }
 
+std::string substr_without_empty_lines(
+  std::string string,
+  std::size_t init_pos,
+  std::size_t end_pos)
+{
+  std::stringstream stream_in(string.substr(init_pos, end_pos - init_pos));
+  std::stringstream stream_out;
+  std::string line;
+  bool first = true;
+  while (std::getline(stream_in, line)) {
+    if (!(line.empty() || line.find_first_not_of(' ') == std::string::npos)) {
+      if (first) {
+        first = false;
+      } else {
+        stream_out << "\n";
+      }
+      stream_out << line;
+    }
+  }
+  return stream_out.str();
+}
+
+std::string remove_comments(const std::string & pddl)
+{
+  std::stringstream uncomment;
+
+  std::size_t pddl_length = pddl.length();
+  std::size_t start_pos = 0;
+  std::size_t end_pos = 0;
+  bool commented = false;
+  while (end_pos < pddl_length) {
+    if ((!commented) && (pddl.at(end_pos) == ';')) {
+      commented = true;
+      uncomment << pddl.substr(start_pos, end_pos - start_pos);
+    }
+
+    if (commented && (pddl.at(end_pos) == '\r' || pddl.at(end_pos) == '\n')) {
+      commented = false;
+      start_pos = end_pos;
+    }
+    end_pos++;
+  }
+  if (!commented) {
+    uncomment << pddl.substr(start_pos, end_pos - start_pos);
+  }
+  return std::string(uncomment.str());
+}
 }  // namespace plansys2

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainReader.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainReader.cpp
@@ -154,8 +154,7 @@ DomainReader::get_requirements(std::string & domain)
   auto end_pos = get_end_block(domain, init_pos);
 
   if (end_pos >= 0) {
-    auto ret = domain.substr(init_pos, end_pos - init_pos);
-
+    auto ret = substr_without_empty_lines(domain, init_pos, end_pos);
     // We remove the requirements part for not interfering with next analysis
     domain.replace(init_pos, end_pos - init_pos, "");
 

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainReader.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainReader.cpp
@@ -15,6 +15,7 @@
 #include "plansys2_domain_expert/DomainReader.hpp"
 
 #include <string>
+#include <sstream>
 #include <vector>
 #include <algorithm>
 #include <iostream>
@@ -45,6 +46,8 @@ DomainReader::add_domain(const std::string & domain)
     domain.begin(), domain.end(), lc_domain.begin(),
     [](unsigned char c) {return std::tolower(c);});
 
+  lc_domain = remove_comments(lc_domain);
+
   new_domain.requirements = get_requirements(lc_domain);
   new_domain.types = get_types(lc_domain);
   new_domain.predicates = get_predicates(lc_domain);
@@ -73,7 +76,9 @@ DomainReader::get_joint_domain() const
 
   ret += "(:types\n";
   for (auto & domain : domains_) {
-    ret += domain.types + "\n";
+    if (!domain.types.empty()) {
+      ret += domain.types + "\n";
+    }
   }
   ret += ")\n\n";
 
@@ -90,13 +95,17 @@ DomainReader::get_joint_domain() const
 
   ret += "(:functions\n";
   for (auto & domain : domains_) {
-    ret += domain.functions + "\n";
+    if (!domain.functions.empty()) {
+      ret += domain.functions + "\n";
+    }
   }
   ret += ")\n\n";
 
   for (auto & domain : domains_) {
     for (auto & action : domain.actions) {
-      ret += action + "\n";
+      if (!action.empty()) {
+        ret += action + "\n";
+      }
     }
   }
 
@@ -170,7 +179,8 @@ DomainReader::get_types(const std::string & domain)
   auto end_pos = get_end_block(domain, init_pos);
 
   if (end_pos >= 0) {
-    return domain.substr(init_pos, end_pos - init_pos);
+    std::string ret = substr_without_empty_lines(domain, init_pos, end_pos);
+    return ret;
   } else {
     return "";
   }
@@ -190,7 +200,8 @@ DomainReader::get_predicates(const std::string & domain)
   auto end_pos = get_end_block(domain, init_pos);
 
   if (end_pos >= 0) {
-    return domain.substr(init_pos, end_pos - init_pos);
+    std::string ret = substr_without_empty_lines(domain, init_pos, end_pos);
+    return ret;
   } else {
     return "";
   }
@@ -210,7 +221,8 @@ DomainReader::get_functions(const std::string & domain)
   auto end_pos = get_end_block(domain, init_pos);
 
   if (end_pos >= 0) {
-    return domain.substr(init_pos, end_pos - init_pos);
+    std::string ret = substr_without_empty_lines(domain, init_pos, end_pos);
+    return ret;
   } else {
     return "";
   }
@@ -240,12 +252,14 @@ DomainReader::get_actions(const std::string & domain)
         break;
       }
 
-      ret.push_back("(" + ldomain.substr(pos, end_pos - pos + 1));
+      std::string lines = substr_without_empty_lines(ldomain, pos, end_pos + 1);
+      ret.push_back("(" + lines);
       ldomain = ldomain.substr(end_pos + 1);
     }
   } while (!ldomain.empty() && pos != std::string::npos);
 
   return ret;
 }
+
 
 }  // namespace plansys2

--- a/plansys2_domain_expert/test/pddl/domain_combined_processed.pddl
+++ b/plansys2_domain_expert/test/pddl/domain_combined_processed.pddl
@@ -2,18 +2,14 @@
 (:requirements :adl :durative-actions :fluents :strips :typing )
 
 (:types
-
 person  - object 
 message - object
 robot   - object
 room    - object
 teleporter_room - room
-
-
 robot
 pickable_object
 room
-
 )
 
 (:predicates
@@ -26,12 +22,7 @@ room
 )
 
 (:functions
-
     (teleportation_time ?from - teleporter_room ?to - room)
-
-
-
-
 )
 
 (:durative-action move

--- a/plansys2_domain_expert/test/pddl/domain_simple.pddl
+++ b/plansys2_domain_expert/test/pddl/domain_simple.pddl
@@ -5,6 +5,7 @@
 (:types
 person  - object 
 message - object
+; This bracket inside a comment, is here for testing purpose :-)
 robot   - object
 room    - object
 teleporter_room - room
@@ -65,6 +66,7 @@ teleporter_room - room
     )
     :effect (and
         (person_at ?p ?r2)
+        ; This bracket inside a comment, is here for testing purpose : '('
         (not(person_at ?p ?r1))
     )
 )

--- a/plansys2_domain_expert/test/pddl/domain_simple_processed.pddl
+++ b/plansys2_domain_expert/test/pddl/domain_simple_processed.pddl
@@ -2,13 +2,11 @@
 (:requirements :adl :durative-actions :fluents :strips :typing )
 
 (:types
-
 person  - object 
 message - object
 robot   - object
 room    - object
 teleporter_room - room
-
 )
 
 (:predicates
@@ -19,9 +17,7 @@ teleporter_room - room
 )
 
 (:functions
-
     (teleportation_time ?from - teleporter_room ?to - room)
-
 )
 
 (:durative-action move

--- a/plansys2_domain_expert/test/pddl/factory_processed.pddl
+++ b/plansys2_domain_expert/test/pddl/factory_processed.pddl
@@ -2,12 +2,10 @@
 (:requirements :adl :durative-actions :fluents :strips :typing )
 
 (:types
-
 	robot - object
 	zone - object
 	piece - object
 	car - object
-
 )
 
 (:predicates
@@ -23,7 +21,6 @@
 )
 
 (:functions
-
 )
 
 (:durative-action move

--- a/plansys2_domain_expert/test/unit/domain_reader_test.cpp
+++ b/plansys2_domain_expert/test/unit/domain_reader_test.cpp
@@ -102,18 +102,26 @@ TEST(domain_reader, requirements)
   std::string req1_estr = " :strips :typing :adl :fluents :durative-actions";
 
   std::string req2_str = "(\n:requirements :strips :typing :adl :fluents :durative-actions\n)";
-  std::string req2_estr = " :strips :typing :adl :fluents :durative-actions\n";
+  std::string req2_estr = " :strips :typing :adl :fluents :durative-actions";
 
   std::string req3_str = "(:requirements :strips :typing :adl :fluents :durative-actions\n) (\n))";
-  std::string req3_estr = " :strips :typing :adl :fluents :durative-actions\n";
+  std::string req3_estr = " :strips :typing :adl :fluents :durative-actions";
 
   std::string req4_str = "(:requirements :strips :typing :adl :fluents :durative-actions";
   std::string req4_estr = "";
+
+  std::string req5_str = "(:requirements )";
+  std::string req5_estr = "";
+
+  std::string req6_str = "";
+  std::string req6_estr = "";
 
   auto res1 = dr.get_requirements_test(req1_str);
   auto res2 = dr.get_requirements_test(req2_str);
   auto res3 = dr.get_requirements_test(req3_str);
   auto res4 = dr.get_requirements_test(req4_str);
+  auto res5 = dr.get_requirements_test(req5_str);
+  auto res6 = dr.get_requirements_test(req6_str);
 
   ASSERT_EQ(res1, req1_estr);
   ASSERT_EQ(req1_str, "(:requirements)");
@@ -123,6 +131,8 @@ TEST(domain_reader, requirements)
 
   ASSERT_EQ(res3, req3_estr);
   ASSERT_EQ(res4, req4_estr);
+  ASSERT_EQ(res5, req5_estr);
+  ASSERT_EQ(res6, req6_estr);
 }
 
 TEST(domain_reader, types)
@@ -144,17 +154,27 @@ TEST(domain_reader, types)
   std::string req5_str = "(:types\ntype1\ntype2\n";
   std::string req5_estr = "";
 
+  std::string req6_str = "(:types )";
+  std::string req6_estr = "";
+
+  std::string req7_str = "";
+  std::string req7_estr = "";
+
   auto res1 = dr.get_types_test(req1_str);
   auto res2 = dr.get_types_test(req2_str);
   auto res3 = dr.get_types_test(req3_str);
   auto res4 = dr.get_types_test(req4_str);
   auto res5 = dr.get_types_test(req5_str);
+  auto res6 = dr.get_types_test(req6_str);
+  auto res7 = dr.get_types_test(req7_str);
 
   ASSERT_EQ(res1, req1_estr);
   ASSERT_EQ(res2, req2_estr);
   ASSERT_EQ(res3, req3_estr);
   ASSERT_EQ(res4, req4_estr);
   ASSERT_EQ(res5, req5_estr);
+  ASSERT_EQ(res6, req6_estr);
+  ASSERT_EQ(res7, req7_estr);
 }
 
 TEST(domain_reader, predicates)
@@ -167,12 +187,22 @@ TEST(domain_reader, predicates)
   std::string req2_str = "(:predicates\n(robot_at leia bedroom) (person_at paco kitchen\n";
   std::string req2_estr = "";
 
+  std::string req3_str = "(:predicates )";
+  std::string req3_estr = "";
+
+  std::string req4_str = "";
+  std::string req4_estr = "";
+
 
   auto res1 = dr.get_predicates_test(req1_str);
   auto res2 = dr.get_predicates_test(req2_str);
+  auto res3 = dr.get_predicates_test(req3_str);
+  auto res4 = dr.get_predicates_test(req4_str);
 
   ASSERT_EQ(res1, req1_estr);
   ASSERT_EQ(res2, req2_estr);
+  ASSERT_EQ(res3, req3_estr);
+  ASSERT_EQ(res4, req4_estr);
 }
 
 TEST(domain_reader, functions)
@@ -187,12 +217,22 @@ TEST(domain_reader, functions)
     "(:functions\n(=(robot_at leia bedroom) 10)\n(=(person_at paco kitchen) 30\n)";
   std::string req2_estr = "";
 
+  std::string req3_str = "(:functions )";
+  std::string req3_estr = "";
+
+  std::string req4_str = "";
+  std::string req4_estr = "";
+
 
   auto res1 = dr.get_functions_test(req1_str);
   auto res2 = dr.get_functions_test(req2_str);
+  auto res3 = dr.get_functions_test(req3_str);
+  auto res4 = dr.get_functions_test(req4_str);
 
   ASSERT_EQ(res1, req1_estr);
   ASSERT_EQ(res2, req2_estr);
+  ASSERT_EQ(res3, req3_estr);
+  ASSERT_EQ(res4, req4_estr);
 }
 
 TEST(domain_reader, actions)
@@ -218,12 +258,15 @@ TEST(domain_reader, actions)
     std::string("(:durative-action\n  whatever\n");
   std::string req4_1_estr = "(:action\n   whatever\n)";
 
+  std::string req5_str = std::string("");
+
 
   auto res0 = dr.get_actions_test(req0_str);
   auto res1 = dr.get_actions_test(req1_str);
   auto res2 = dr.get_actions_test(req2_str);
   auto res3 = dr.get_actions_test(req3_str);
   auto res4 = dr.get_actions_test(req4_str);
+  auto res5 = dr.get_actions_test(req5_str);
 
   ASSERT_TRUE(res0.empty());
 
@@ -241,6 +284,8 @@ TEST(domain_reader, actions)
 
   ASSERT_EQ(res4.size(), 1u);
   ASSERT_EQ(res4[0], req4_1_estr);
+
+  ASSERT_EQ(res5.size(), 0u);
 }
 
 TEST(domain_reader, add_domain)

--- a/plansys2_domain_expert/test/unit/domain_reader_test.cpp
+++ b/plansys2_domain_expert/test/unit/domain_reader_test.cpp
@@ -133,13 +133,13 @@ TEST(domain_reader, types)
   std::string req1_estr = " type1 type2";
 
   std::string req2_str = "(:types\ntype1 type2\n)";
-  std::string req2_estr = "\ntype1 type2\n";
+  std::string req2_estr = "type1 type2";
 
   std::string req3_str = "(:types\ntype1\ntype2\n)";
-  std::string req3_estr = "\ntype1\ntype2\n";
+  std::string req3_estr = "type1\ntype2";
 
   std::string req4_str = "(:types\ntype1\ntype2\n) ) ";
-  std::string req4_estr = "\ntype1\ntype2\n";
+  std::string req4_estr = "type1\ntype2";
 
   std::string req5_str = "(:types\ntype1\ntype2\n";
   std::string req5_estr = "";
@@ -162,7 +162,7 @@ TEST(domain_reader, predicates)
   DomainReaderTest dr;
 
   std::string req1_str = "(:predicates\n(robot_at leia bedroom) (person_at paco kitchen)\n)";
-  std::string req1_estr = "\n(robot_at leia bedroom) (person_at paco kitchen)\n";
+  std::string req1_estr = "(robot_at leia bedroom) (person_at paco kitchen)";
 
   std::string req2_str = "(:predicates\n(robot_at leia bedroom) (person_at paco kitchen\n";
   std::string req2_estr = "";
@@ -181,7 +181,7 @@ TEST(domain_reader, functions)
 
   std::string req1_str =
     "(:functions\n(=(robot_at leia bedroom) 10)\n(=(person_at paco kitchen) 30)\n)";
-  std::string req1_estr = "\n(=(robot_at leia bedroom) 10)\n(=(person_at paco kitchen) 30)\n";
+  std::string req1_estr = "(=(robot_at leia bedroom) 10)\n(=(person_at paco kitchen) 30)";
 
   std::string req2_str =
     "(:functions\n(=(robot_at leia bedroom) 10)\n(=(person_at paco kitchen) 30\n)";


### PR DESCRIPTION
This PR is related to #65.
It aim to ignore the brackets inside the comments of a PDDL file.