### PR TITLE
Change 'move' action name

### DIFF
--- a/plansys2_bt_actions/test/unit/CMakeLists.txt
+++ b/plansys2_bt_actions/test/unit/CMakeLists.txt
@@ -8,8 +8,8 @@ add_library(plansys2_open_gripper_bt_node SHARED
 )
 list(APPEND plugin_libs plansys2_open_gripper_bt_node)
 
-add_library(plansys2_move_bt_node SHARED ../behavior_tree/Move.cpp)
-list(APPEND plugin_libs plansys2_move_bt_node)
+add_library(plansys2_move_bt_test_node SHARED ../behavior_tree/Move.cpp)
+list(APPEND plugin_libs plansys2_move_bt_test_node)
 
 foreach(bt_plugin ${plugin_libs})
   ament_target_dependencies(${bt_plugin} ${dependencies})

--- a/plansys2_bt_actions/test/unit/bt_action_test.cpp
+++ b/plansys2_bt_actions/test/unit/bt_action_test.cpp
@@ -109,7 +109,7 @@ TEST(bt_actions, load_plugins)
 
   factory.registerFromPlugin(loader.getOSName("plansys2_close_gripper_bt_node"));
   factory.registerFromPlugin(loader.getOSName("plansys2_open_gripper_bt_node"));
-  factory.registerFromPlugin(loader.getOSName("plansys2_move_bt_node"));
+  factory.registerFromPlugin(loader.getOSName("plansys2_move_bt_test_node"));
 
   std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_bt_actions");
   std::string xml_file = pkgpath + "/test/behavior_tree/transport.xml";


### PR DESCRIPTION
This PR aim to be able to perform tests (colcon test) in a workspace containing the `ros2_planning_system` and the `ros2_planning_system_example` repositories.

The "plansys2_move_bt_node" is existing on both, but the one in the example repository does not have a "goal_reached" parameter witch cause a failure in the test `be_action_test\bt_actions/load_plugins`.

Signed-off-by: Fabrice Larribe <fabrice.larribe@safrangroup.com>