### PR TITLE
Add support to plansys2_executor/ExecutorNode for visualizing the beh…

### DIFF
--- a/plansys2_executor/CMakeLists.txt
+++ b/plansys2_executor/CMakeLists.txt
@@ -2,6 +2,8 @@ project(plansys2_executor)
 
 cmake_minimum_required(VERSION 3.5)
 
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+
 find_package(Threads REQUIRED)
 
 find_package(ament_cmake REQUIRED)
@@ -18,6 +20,14 @@ find_package(plansys2_problem_expert REQUIRED)
 find_package(plansys2_planner REQUIRED)
 find_package(behaviortree_cpp_v3 REQUIRED)
 find_package(std_msgs REQUIRED)
+
+find_package(ZMQ)
+if(ZMQ_FOUND)
+    message(STATUS "ZeroMQ found.")
+    add_definitions(-DZMQ_FOUND)
+else()
+  message(WARNING "ZeroMQ NOT found. Not including PublisherZMQ.")
+endif()
 
 set(CMAKE_CXX_STANDARD 17)
 
@@ -37,7 +47,7 @@ set(dependencies
     std_msgs
 )
 
-include_directories(include)
+include_directories(include ${ZMQ_INCLUDE_DIRS})
 
 set(EXECUTOR_SOURCES
   src/plansys2_executor/ExecutorClient.cpp
@@ -58,6 +68,7 @@ set(EXECUTOR_SOURCES
 
 add_library(${PROJECT_NAME} SHARED ${EXECUTOR_SOURCES})
 ament_target_dependencies(${PROJECT_NAME} ${dependencies})
+target_link_libraries(${PROJECT_NAME} ${ZMQ_LIBRARIES})
 
 add_executable(executor_node
   src/executor_node.cpp

--- a/plansys2_executor/cmake/FindZMQ.cmake
+++ b/plansys2_executor/cmake/FindZMQ.cmake
@@ -1,0 +1,84 @@
+# - Try to find ZMQ
+# Once done this will define
+#
+#  ZMQ_FOUND - system has ZMQ
+#  ZMQ_INCLUDE_DIRS - the ZMQ include directory
+#  ZMQ_LIBRARIES - Link these to use ZMQ
+#  ZMQ_DEFINITIONS - Compiler switches required for using ZMQ
+#
+#  Copyright (c) 2011 Lee Hambley <lee.hambley@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the copyright holder nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+#  Original license text (changed to the above to pass ament_copyright):
+#  Redistribution and use is allowed according to the terms of the New
+#  BSD license.
+#  For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+#
+
+if(ZMQ_LIBRARIES AND ZMQ_INCLUDE_DIRS)
+  # in cache already
+  set(ZMQ_FOUND TRUE)
+else()
+
+  find_path(ZMQ_INCLUDE_DIR
+    NAMES
+      zmq.h
+    PATHS
+      /usr/include
+      /usr/local/include
+      /opt/local/include
+  )
+
+  find_library(ZMQ_LIBRARY
+    NAMES
+      zmq
+    PATHS
+      /usr/lib
+      /usr/local/lib
+      /opt/local/lib
+      /sw/lib
+  )
+
+  set(ZMQ_INCLUDE_DIRS
+    ${ZMQ_INCLUDE_DIR}
+  )
+
+  if(ZMQ_LIBRARY)
+    set(ZMQ_LIBRARIES
+        ${ZMQ_LIBRARIES}
+        ${ZMQ_LIBRARY}
+    )
+  endif()
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(ZMQ DEFAULT_MSG ZMQ_LIBRARIES ZMQ_INCLUDE_DIRS)
+
+  # show the ZMQ_INCLUDE_DIRS and ZMQ_LIBRARIES variables only in the advanced view
+  mark_as_advanced(ZMQ_INCLUDE_DIRS ZMQ_LIBRARIES)
+
+endif()

--- a/plansys2_executor/package.xml
+++ b/plansys2_executor/package.xml
@@ -25,6 +25,7 @@
   <depend>plansys2_planner</depend>
   <depend>behaviortree_cpp_v3</depend>
   <depend>std_msgs</depend>
+  <depend>libzmq3-dev</depend>
 
   <exec_depend>popf</exec_depend>
 

--- a/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
+++ b/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
@@ -34,6 +34,10 @@
 #include "behaviortree_cpp_v3/utils/shared_library.h"
 #include "behaviortree_cpp_v3/blackboard.h"
 
+#ifdef ZMQ_FOUND
+#include <behaviortree_cpp_v3/loggers/bt_zmq_publisher.h>
+#endif
+
 #include "plansys2_executor/behavior_tree/execute_action_node.hpp"
 #include "plansys2_executor/behavior_tree/wait_action_node.hpp"
 #include "plansys2_executor/behavior_tree/wait_atstart_req_node.hpp"
@@ -52,6 +56,13 @@ ExecutorNode::ExecutorNode()
 : rclcpp_lifecycle::LifecycleNode("executor")
 {
   using namespace std::placeholders;
+
+#ifdef ZMQ_FOUND
+  this->declare_parameter<bool>("enable_groot_monitoring", true);
+  this->declare_parameter<int>("publisher_port", 1666);
+  this->declare_parameter<int>("server_port", 1667);
+  this->declare_parameter<int>("max_msgs_per_second", 25);
+#endif
 
   execute_plan_action_server_ = rclcpp_action::create_server<ExecutePlan>(
     this->get_node_base_interface(),
@@ -219,6 +230,28 @@ ExecutorNode::execute(const std::shared_ptr<GoalHandleExecutePlan> goal_handle)
   out.close();
 
   auto tree = factory.createTreeFromText(bt_xml_tree, blackboard);
+
+#ifdef ZMQ_FOUND
+  unsigned int publisher_port = this->get_parameter("publisher_port").as_int();
+  unsigned int server_port = this->get_parameter("server_port").as_int();
+  unsigned int max_msgs_per_second = this->get_parameter("max_msgs_per_second").as_int();
+
+  std::unique_ptr<BT::PublisherZMQ> publisher_zmq;
+  if (this->get_parameter("enable_groot_monitoring").as_bool()) {
+    RCLCPP_INFO(
+      get_logger(),
+      "[%s] Groot monitoring: Publisher port: %d, Server port: %d, Max msgs per second: %d",
+      get_name(), publisher_port, server_port, max_msgs_per_second);
+    try {
+      publisher_zmq.reset(
+        new BT::PublisherZMQ(
+          tree, max_msgs_per_second, publisher_port,
+          server_port));
+    } catch (const BT::LogicError & exc) {
+      RCLCPP_ERROR(get_logger(), "ZMQ already enabled, Error: %s", exc.what());
+    }
+  }
+#endif
 
   auto info_pub = create_wall_timer(
     1s, [this, &action_map]() {


### PR DESCRIPTION
…avior trees in Groot.

Signed-off-by: Alexander Xydes <alexander.xydes@navy.mil>

*Testing*
* Basing the test off of the bt example in the ros2_planning_system_examples repository.
  * https://github.com/IntelligentRoboticsLabs/ros2_planning_system_examples/tree/master/plansys2_bt_example
* Create a workspace from this repos file: 
[plansys2_groot.repos.txt](https://github.com/IntelligentRoboticsLabs/ros2_planning_system/files/5920631/plansys2_groot.repos.txt)
* Terminal 1: `ros2 launch nav2_bringup tb3_simulation_launch.py`
* Terminal 2: `ros2 launch plansys2_bt_example plansys2_bt_example_launch.py`
* Terminal 3: `ros2 run groot Groot`
  * Click `Monitor`, then `Start`
* Terminal 4:
```
ros2 run plansys2_terminal plansys2_terminal
set instance r2d2 robot

set instance wheels_zone zone
set instance steering_wheels_zone zone
set instance body_car_zone zone
set instance assembly_zone zone

set instance wheel_1 piece
set instance body_car_1 piece
set instance steering_wheel_1 piece

set predicate (piece_at wheel_1 wheels_zone)
set predicate (piece_at body_car_1 body_car_zone)
set predicate (piece_at steering_wheel_1 steering_wheels_zone)

set predicate (robot_at r2d2 assembly_zone)

set goal (and(piece_at wheel_1 assembly_zone))
run
```
* After you type `run` and hit enter in Terminal 4 and the plan starts executing, in the Groot window, click `Connect`
  *  Verify that you see the plan execution behavior tree appear, and update when the execution updates. Nodes should be highlighted when they are running. Note that nothing will be highlighted when it first connects, node highlighting only updates when the plan execution changes (i.e. moves from one node to the next).