### PR TITLE
utils-bug: Fixing bug in OR case of evaluate function in plansys2_exe…

### DIFF
--- a/plansys2_executor/src/plansys2_executor/Utils.cpp
+++ b/plansys2_executor/src/plansys2_executor/Utils.cpp
@@ -57,7 +57,7 @@ std::tuple<bool, bool, double> evaluate(
         std::shared_ptr<parser::pddl::tree::OrNode> pn_or =
           std::dynamic_pointer_cast<parser::pddl::tree::OrNode>(node);
         bool success = true;
-        bool truth_value = true;
+        bool truth_value = false;
 
         for (const auto & op : pn_or->ops) {
           std::tuple<bool, bool, double> result =


### PR DESCRIPTION
We discovered a bug in the OR case of the evaluate function in Utils.cpp. When aggregating truth values using an OR operator, the initial value should be false. As a side note, we are working on a unit test for Utils.cpp and hope to create another PR soon.

Signed-off-by: Josh Zapf <jjzapf@spawar.navy.mil>