### PR TITLE
Add Groot ZeroMQ-based visualization of the BehaviorTree in each BTActionNode.

### DIFF
--- a/plansys2_bt_actions/CMakeLists.txt
+++ b/plansys2_bt_actions/CMakeLists.txt
@@ -2,6 +2,8 @@ project(plansys2_bt_actions)
 
 cmake_minimum_required(VERSION 3.5)
 
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+
 find_package(Threads REQUIRED)
 
 find_package(ament_cmake REQUIRED)
@@ -12,6 +14,14 @@ find_package(plansys2_executor REQUIRED)
 find_package(behaviortree_cpp_v3 REQUIRED)
 find_package(action_msgs REQUIRED)
 find_package(lifecycle_msgs REQUIRED)
+
+find_package(ZMQ)
+if(ZMQ_FOUND)
+    message(STATUS "ZeroMQ found.")
+    add_definitions(-DZMQ_FOUND)
+else()
+  message(WARNING "ZeroMQ NOT found. Not including PublisherZMQ.")
+endif()
 
 set(CMAKE_CXX_STANDARD 17)
 
@@ -25,7 +35,7 @@ set(dependencies
     lifecycle_msgs
 )
 
-include_directories(include)
+include_directories(include ${ZMQ_INCLUDE_DIRS})
 
 set(BT_ACTIONS_SOURCES
   src/plansys2_bt_actions/BTAction.cpp
@@ -33,6 +43,7 @@ set(BT_ACTIONS_SOURCES
 
 add_library(${PROJECT_NAME} SHARED ${BT_ACTIONS_SOURCES})
 ament_target_dependencies(${PROJECT_NAME} ${dependencies})
+target_link_libraries(${PROJECT_NAME} ${ZMQ_LIBRARIES})
 
 add_executable(bt_action_node
   src/bt_action_node.cpp

--- a/plansys2_bt_actions/cmake/FindZMQ.cmake
+++ b/plansys2_bt_actions/cmake/FindZMQ.cmake
@@ -1,0 +1,84 @@
+# - Try to find ZMQ
+# Once done this will define
+#
+#  ZMQ_FOUND - system has ZMQ
+#  ZMQ_INCLUDE_DIRS - the ZMQ include directory
+#  ZMQ_LIBRARIES - Link these to use ZMQ
+#  ZMQ_DEFINITIONS - Compiler switches required for using ZMQ
+#
+#  Copyright (c) 2011 Lee Hambley <lee.hambley@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the copyright holder nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+#  Original license text (changed to the above to pass ament_copyright):
+#  Redistribution and use is allowed according to the terms of the New
+#  BSD license.
+#  For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+#
+
+if(ZMQ_LIBRARIES AND ZMQ_INCLUDE_DIRS)
+  # in cache already
+  set(ZMQ_FOUND TRUE)
+else()
+
+  find_path(ZMQ_INCLUDE_DIR
+    NAMES
+      zmq.h
+    PATHS
+      /usr/include
+      /usr/local/include
+      /opt/local/include
+  )
+
+  find_library(ZMQ_LIBRARY
+    NAMES
+      zmq
+    PATHS
+      /usr/lib
+      /usr/local/lib
+      /opt/local/lib
+      /sw/lib
+  )
+
+  set(ZMQ_INCLUDE_DIRS
+    ${ZMQ_INCLUDE_DIR}
+  )
+
+  if(ZMQ_LIBRARY)
+    set(ZMQ_LIBRARIES
+        ${ZMQ_LIBRARIES}
+        ${ZMQ_LIBRARY}
+    )
+  endif()
+
+  include(FindPackageHandleStandardArgs)
+  find_package_handle_standard_args(ZMQ DEFAULT_MSG ZMQ_LIBRARIES ZMQ_INCLUDE_DIRS)
+
+  # show the ZMQ_INCLUDE_DIRS and ZMQ_LIBRARIES variables only in the advanced view
+  mark_as_advanced(ZMQ_INCLUDE_DIRS ZMQ_LIBRARIES)
+
+endif()

--- a/plansys2_bt_actions/include/plansys2_bt_actions/BTAction.hpp
+++ b/plansys2_bt_actions/include/plansys2_bt_actions/BTAction.hpp
@@ -15,12 +15,17 @@
 #ifndef PLANSYS2_BT_ACTIONS__BTACTION_HPP_
 #define PLANSYS2_BT_ACTIONS__BTACTION_HPP_
 
+#include <memory>
 #include <string>
 #include <vector>
 
 #include "behaviortree_cpp_v3/behavior_tree.h"
 #include "behaviortree_cpp_v3/bt_factory.h"
 #include "behaviortree_cpp_v3/xml_parsing.h"
+
+#ifdef ZMQ_FOUND
+#include <behaviortree_cpp_v3/loggers/bt_zmq_publisher.h>
+#endif
 
 #include "plansys2_executor/ActionExecutorClient.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -43,6 +48,9 @@ protected:
   on_configure(const rclcpp_lifecycle::State & previous_state);
 
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_cleanup(const rclcpp_lifecycle::State & previous_state);
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_activate(const rclcpp_lifecycle::State & previous_state);
 
   void do_work();
@@ -55,6 +63,7 @@ private:
   std::string action_;
   std::string bt_xml_file_;
   std::vector<std::string> plugin_list_;
+  std::unique_ptr<BT::PublisherZMQ> publisher_zmq_;
 };
 
 }  // namespace plansys2

--- a/plansys2_bt_actions/package.xml
+++ b/plansys2_bt_actions/package.xml
@@ -18,6 +18,7 @@
   <depend>plansys2_executor</depend>
   <depend>behaviortree_cpp_v3</depend>
   <depend>action_msgs</depend>
+  <depend>libzmq3-dev</depend>
 
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/plansys2_bt_actions/src/plansys2_bt_actions/BTAction.cpp
+++ b/plansys2_bt_actions/src/plansys2_bt_actions/BTAction.cpp
@@ -72,11 +72,12 @@ BTAction::on_configure(const rclcpp_lifecycle::State & previous_state)
   unsigned int max_msgs_per_second = get_parameter("max_msgs_per_second").as_int();
 
   if (publisher_port <= 0 || server_port <= 0) {
-    RCLCPP_WARN(get_logger(),
-      "[%s] Groot monitoring ports not provided, disabling Groot monitoring. publisher port: %d, server port: d",
+    RCLCPP_WARN(
+      get_logger(),
+      "[%s] Groot monitoring ports not provided, disabling Groot monitoring."
+      " publisher port: %d, server port: %d",
       get_name(), publisher_port, server_port);
-  }
-  else if (get_parameter("enable_groot_monitoring").as_bool()) {
+  } else if (get_parameter("enable_groot_monitoring").as_bool()) {
     RCLCPP_INFO(
       get_logger(),
       "[%s] Groot monitoring: Publisher port: %d, Server port: %d, Max msgs per second: %d",

--- a/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
+++ b/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
@@ -248,7 +248,7 @@ ExecutorNode::execute(const std::shared_ptr<GoalHandleExecutePlan> goal_handle)
           tree, max_msgs_per_second, publisher_port,
           server_port));
     } catch (const BT::LogicError & exc) {
-      RCLCPP_ERROR(get_logger(), "ZMQ already enabled, Error: %s", exc.what());
+      RCLCPP_ERROR(get_logger(), "ZMQ error: %s", exc.what());
     }
   }
 #endif


### PR DESCRIPTION
Fixes #86 

*Testing*
* Basing the test off of the bt example in the ros2_planning_system_examples repository.
  * https://github.com/IntelligentRoboticsLabs/ros2_planning_system_examples/tree/master/plansys2_bt_example
* Create a workspace from this repos file: 
[bt-action-visualization.repos.txt](https://github.com/IntelligentRoboticsLabs/ros2_planning_system/files/5991987/bt-action-visualization.repos.txt)
* Terminal 1: `ros2 launch nav2_bringup tb3_simulation_launch.py`
* Terminal 2: `ros2 launch plansys2_bt_example plansys2_bt_example_launch.py`
* Terminal 3: `ros2 run groot Groot`
  * Click `Monitor`, then `Start`
  * Change the publisher and server ports to match one of the pairs in this [file](https://github.com/IntelligentRoboticsLabs/ros2_planning_system_examples/compare/master...xydesa:bt-action-visualization#diff-fca9fd4e3033110d0c48f9781b42611e4a93fd4af6c004dbdecc5ea69363f4a3)
* Terminal 4:
```
ros2 run plansys2_terminal plansys2_terminal
set instance r2d2 robot

set instance wheels_zone zone
set instance steering_wheels_zone zone
set instance body_car_zone zone
set instance assembly_zone zone

set instance wheel_1 piece
set instance body_car_1 piece
set instance steering_wheel_1 piece

set predicate (piece_at wheel_1 wheels_zone)
set predicate (piece_at body_car_1 body_car_zone)
set predicate (piece_at steering_wheel_1 steering_wheels_zone)

set predicate (robot_at r2d2 assembly_zone)

set goal (and(piece_at wheel_1 assembly_zone))
run
```
* After you type `run` and hit enter in Terminal 4 and the plan starts executing, in the Groot window, click `Connect`
  *  Verify that you see the plan execution behavior tree appear, and update when the execution updates. Nodes should be highlighted when they are running. Note that nothing will be highlighted when it first connects, node highlighting only updates when the plan execution changes (i.e. moves from one node to the next).
  * Note that the BehaviorTrees for the BTActionNodes in the example used seem to be very simple, but they should still highlight as they get executed.