### PR TITLE
Action execution refactoring

### DIFF
--- a/plansys2_bt_actions/include/plansys2_bt_actions/BTAction.hpp
+++ b/plansys2_bt_actions/include/plansys2_bt_actions/BTAction.hpp
@@ -45,6 +45,9 @@ protected:
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_activate(const rclcpp_lifecycle::State & previous_state);
 
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_deactivate(const rclcpp_lifecycle::State & previous_state);
+
   void do_work();
 
   BT::BehaviorTreeFactory factory_;
@@ -55,6 +58,7 @@ private:
   std::string action_;
   std::string bt_xml_file_;
   std::vector<std::string> plugin_list_;
+  bool finished_;
 };
 
 }  // namespace plansys2

--- a/plansys2_executor/include/plansys2_executor/ActionExecutor.hpp
+++ b/plansys2_executor/include/plansys2_executor/ActionExecutor.hpp
@@ -40,7 +40,8 @@ public:
     DEALING,
     RUNNING,
     SUCCESS,
-    FAILURE
+    FAILURE,
+    CANCELLED
   };
 
   using Ptr = std::shared_ptr<ActionExecutor>;
@@ -55,6 +56,7 @@ public:
     const std::string & action, rclcpp_lifecycle::LifecycleNode::SharedPtr node);
 
   BT::NodeStatus tick(const rclcpp::Time & now);
+  void cancel();
   BT::NodeStatus get_status();
   bool is_finished();
 
@@ -80,6 +82,7 @@ protected:
 
   std::string action_;
   std::string action_name_;
+  std::string current_performer_id_;
   std::vector<std::string> action_params_;
 
   std::string feedback_;

--- a/plansys2_executor/include/plansys2_executor/ActionExecutorClient.hpp
+++ b/plansys2_executor/include/plansys2_executor/ActionExecutorClient.hpp
@@ -45,6 +45,8 @@ public:
     const std::string & node_name,
     const std::chrono::nanoseconds & rate);
 
+  plansys2_msgs::msg::ActionPerformerStatus get_internal_status() const {return status_;}
+
 protected:
   virtual void do_work() {}
 

--- a/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
+++ b/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
@@ -83,6 +83,7 @@ protected:
     std::shared_ptr<plansys2::ProblemExpertClient> problem_client);
 
   std::vector<ActionStamped> get_plan_actions(const Plan & plan);
+  void prune_backwards(GraphNode::Ptr new_node, GraphNode::Ptr node_satisfy);
 
   bool is_action_executable(
     const ActionStamped & action,
@@ -111,7 +112,10 @@ protected:
     const plansys2::ActionStamped & action,
     const std::list<GraphNode::Ptr> & ret) const;
 
-  std::string get_flow_tree(GraphNode::Ptr node, int level = 0);
+  std::string get_flow_tree(
+    GraphNode::Ptr node,
+    std::list<std::string> & used_nodes,
+    int level = 0);
 
   std::string t(int level);
 

--- a/plansys2_executor/include/plansys2_executor/ExecutorClient.hpp
+++ b/plansys2_executor/include/plansys2_executor/ExecutorClient.hpp
@@ -35,24 +35,35 @@ public:
 
   explicit ExecutorClient(rclcpp::Node::SharedPtr provided_node);
 
-  bool executePlan();
+  bool start_plan_execution();
+  bool execute_and_check_plan();
+  void cancel_plan_execution();
 
   ExecutePlan::Feedback getFeedBack() {return feedback_;}
   std::optional<ExecutePlan::Result> getResult();
 
 private:
   rclcpp::Node::SharedPtr node_;
-  rclcpp_action::Client<ExecutePlan>::SharedPtr execute_plan_client_ptr_;
 
+  rclcpp_action::Client<ExecutePlan>::SharedPtr action_client_;
+
+  ExecutePlan::Goal goal_;
   ExecutePlan::Feedback feedback_;
-  ExecutePlan::Result result_;
-  bool finished_;
+  rclcpp_action::ClientGoalHandle<ExecutePlan>::SharedPtr goal_handle_;
+  rclcpp_action::ClientGoalHandle<ExecutePlan>::WrappedResult result_;
 
-  void feedback_callback(
-    GoalHandleExecutePlan::SharedPtr,
-    const std::shared_ptr<const ExecutePlan::Feedback> feedback);
+  bool goal_result_available_{false};
+
+  bool executing_plan_;
 
   void result_callback(const GoalHandleExecutePlan::WrappedResult & result);
+  void feedback_callback(
+    GoalHandleExecutePlan::SharedPtr goal_handle,
+    const std::shared_ptr<const ExecutePlan::Feedback> feedback);
+
+  bool on_new_goal_received();
+  bool should_cancel_goal();
+  void createActionClient();
 };
 
 }  // namespace plansys2

--- a/plansys2_executor/include/plansys2_executor/ExecutorNode.hpp
+++ b/plansys2_executor/include/plansys2_executor/ExecutorNode.hpp
@@ -56,9 +56,11 @@ public:
   CallbackReturnT on_shutdown(const rclcpp_lifecycle::State & state);
   CallbackReturnT on_error(const rclcpp_lifecycle::State & state);
 
-private:
+protected:
   rclcpp::Node::SharedPtr node_;
   rclcpp::Node::SharedPtr aux_node_;
+
+  bool cancel_plan_requested_;
 
   std::shared_ptr<plansys2::DomainExpertClient> domain_client_;
   std::shared_ptr<plansys2::ProblemExpertClient> problem_client_;
@@ -79,8 +81,6 @@ private:
   void execute(const std::shared_ptr<GoalHandleExecutePlan> goal_handle);
 
   void handle_accepted(const std::shared_ptr<GoalHandleExecutePlan> goal_handle);
-
-  std::optional<Plan> current_plan_;
 
   std::vector<plansys2_msgs::msg::ActionExecutionInfo> get_feedback_info(
     std::shared_ptr<std::map<std::string, ActionExecutionInfo>> action_map);

--- a/plansys2_executor/include/plansys2_executor/behavior_tree/execute_action_node.hpp
+++ b/plansys2_executor/include/plansys2_executor/behavior_tree/execute_action_node.hpp
@@ -37,7 +37,7 @@ public:
     const std::string & xml_tag_name,
     const BT::NodeConfiguration & conf);
 
-  void halt() {}
+  void halt();
   BT::NodeStatus tick() override;
 
   static BT::PortsList providedPorts()

--- a/plansys2_executor/src/plansys2_executor/ActionExecutor.cpp
+++ b/plansys2_executor/src/plansys2_executor/ActionExecutor.cpp
@@ -41,6 +41,8 @@ ActionExecutor::ActionExecutor(
   action_name_ = get_name(action);
   action_params_ = get_params(action);
   completion_ = 0.0;
+  start_execution_ = node_->now();
+  state_time_ = start_execution_;
 }
 
 void
@@ -70,15 +72,20 @@ ActionExecutor::action_hub_callback(const plansys2_msgs::msg::ActionExecution::S
       }
       break;
     case plansys2_msgs::msg::ActionExecution::FEEDBACK:
-      if (state_ != RUNNING || msg->arguments != action_params_ || msg->action != action_name_) {
+      if (state_ != RUNNING || msg->arguments != action_params_ || msg->action != action_name_ ||
+        msg->node_id != current_performer_id_)
+      {
         return;
       }
       feedback_ = msg->status;
       completion_ = msg->completion;
+      state_time_ = node_->now();
 
       break;
     case plansys2_msgs::msg::ActionExecution::FINISH:
-      if (msg->arguments == action_params_ && msg->action == action_name_) {
+      if (msg->arguments == action_params_ &&
+        msg->action == action_name_ && msg->node_id == current_performer_id_)
+      {
         if (msg->success) {
           state_ = SUCCESS;
         } else {

--- a/plansys2_executor/src/plansys2_executor/ActionExecutorClient.cpp
+++ b/plansys2_executor/src/plansys2_executor/ActionExecutorClient.cpp
@@ -84,7 +84,6 @@ CallbackReturnT
 ActionExecutorClient::on_activate(const rclcpp_lifecycle::State & state)
 {
   status_.state = plansys2_msgs::msg::ActionPerformerStatus::RUNNING;
-
   timer_ = create_wall_timer(
     rate_, std::bind(&ActionExecutorClient::do_work, this));
 
@@ -124,6 +123,13 @@ ActionExecutorClient::action_hub_callback(const plansys2_msgs::msg::ActionExecut
     case plansys2_msgs::msg::ActionExecution::REJECT:
       if (msg->node_id == get_name()) {
         commited_ = false;
+      }
+      break;
+    case plansys2_msgs::msg::ActionExecution::CANCEL:
+      if (get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE &&
+        msg->node_id == get_name())
+      {
+        trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
       }
       break;
     case plansys2_msgs::msg::ActionExecution::RESPONSE:

--- a/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
+++ b/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
@@ -568,10 +568,10 @@ BTBuilder::execution_block(const GraphNode::Ptr & node, int l)
   }
 
   ret = ret + t(l + 1) + "<ApplyAtStartEffect action=\"" + action_id + "\"/>\n";
-  ret = ret + t(l + 1) + "<Parallel success_threshold=\"2\" failure_threshold=\"1\">\n";
+  ret = ret + t(l + 1) + "<ReactiveSequence name=\"" + action_id + "\">\n";
   ret = ret + t(l + 2) + "<CheckOverAllReq action=\"" + action_id + "\"/>\n";
   ret = ret + t(l + 2) + "<ExecuteAction action=\"" + action_id + "\"/>\n";
-  ret = ret + t(l + 1) + "</Parallel>\n";
+  ret = ret + t(l + 1) + "</ReactiveSequence>\n";
   ret = ret + t(l + 1) + "<CheckAtEndReq action=\"" + action_id + "\"/>\n";
   ret = ret + t(l + 1) + "<ApplyAtEndEffect action=\"" + action_id + "\"/>\n";
   ret = ret + t(l) + "</Sequence>\n";

--- a/plansys2_executor/src/plansys2_executor/ExecutorClient.cpp
+++ b/plansys2_executor/src/plansys2_executor/ExecutorClient.cpp
@@ -173,6 +173,7 @@ ExecutorClient::result_callback(const GoalHandleExecutePlan::WrappedResult & res
 {
   goal_result_available_ = true;
   result_ = result;
+  feedback_ = ExecutePlan::Feedback();
 }
 
 std::optional<ExecutePlan::Result>

--- a/plansys2_executor/src/plansys2_executor/ExecutorClient.cpp
+++ b/plansys2_executor/src/plansys2_executor/ExecutorClient.cpp
@@ -23,37 +23,83 @@
 namespace plansys2
 {
 
+using namespace std::chrono_literals;
+using namespace std::placeholders;
+
 using ExecutePlan = plansys2_msgs::action::ExecutePlan;
 
 ExecutorClient::ExecutorClient(rclcpp::Node::SharedPtr provided_node)
-: node_(provided_node), finished_(false)
+: node_(provided_node)
 {
-  this->execute_plan_client_ptr_ = rclcpp_action::create_client<ExecutePlan>(
-    node_->get_node_base_interface(),
-    node_->get_node_graph_interface(),
-    node_->get_node_logging_interface(),
-    node_->get_node_waitables_interface(),
-    "execute_plan");
+  createActionClient();
+}
+
+void
+ExecutorClient::createActionClient()
+{
+  action_client_ = rclcpp_action::create_client<ExecutePlan>(node_, "execute_plan");
+
+  if (!this->action_client_->wait_for_action_server(3s)) {
+    RCLCPP_ERROR(node_->get_logger(), "Action server not available after waiting");
+  }
 }
 
 bool
-ExecutorClient::executePlan()
+ExecutorClient::start_plan_execution()
 {
-  using namespace std::placeholders;
+  if (!executing_plan_) {
+    createActionClient();
+    auto success = on_new_goal_received();
 
-  finished_ = false;
-
-  if (!this->execute_plan_client_ptr_) {
-    RCLCPP_ERROR(node_->get_logger(), "Action client not initialized");
+    if (success) {
+      executing_plan_ = true;
+      return true;
+    }
+  } else {
+    RCLCPP_INFO(node_->get_logger(), "Already executing a plan");
   }
 
-  if (!this->execute_plan_client_ptr_->wait_for_action_server(std::chrono::seconds(10))) {
-    RCLCPP_ERROR(node_->get_logger(), "Action server not available after waiting");
-    return false;
+  return false;
+}
+
+bool
+ExecutorClient::execute_and_check_plan()
+{
+  if (rclcpp::ok() && !goal_result_available_) {
+    rclcpp::spin_some(node_);
+
+    if (!goal_result_available_) {
+      return true;  // Plan not finished
+    }
   }
 
-  auto goal_msg = ExecutePlan::Goal();
+  switch (result_.code) {
+    case rclcpp_action::ResultCode::SUCCEEDED:
+      RCLCPP_INFO(node_->get_logger(), "Plan Succeded");
+      break;
 
+    case rclcpp_action::ResultCode::ABORTED:
+      RCLCPP_WARN(node_->get_logger(), "Plan Aborted");
+      break;
+
+    case rclcpp_action::ResultCode::CANCELED:
+      RCLCPP_INFO(node_->get_logger(), "Plan Cancelled");
+      break;
+
+    default:
+      throw std::logic_error("ExecutorClient::executePlan: invalid status value");
+  }
+
+  executing_plan_ = false;
+  goal_result_available_ = false;
+
+  return false;  // Plan finished
+}
+
+
+bool
+ExecutorClient::on_new_goal_received()
+{
   auto send_goal_options = rclcpp_action::Client<ExecutePlan>::SendGoalOptions();
 
   send_goal_options.feedback_callback =
@@ -61,29 +107,62 @@ ExecutorClient::executePlan()
 
   send_goal_options.result_callback =
     std::bind(&ExecutorClient::result_callback, this, _1);
-  auto goal_handle_future = this->execute_plan_client_ptr_->async_send_goal(
-    goal_msg, send_goal_options);
 
-  if (rclcpp::spin_until_future_complete(node_, goal_handle_future) !=
-    rclcpp::executor::FutureReturnCode::SUCCESS)
+  auto future_goal_handle = action_client_->async_send_goal(goal_, send_goal_options);
+
+  if (rclcpp::spin_until_future_complete(
+      node_->get_node_base_interface(), future_goal_handle, 3s) !=
+    rclcpp::FutureReturnCode::SUCCESS)
   {
     RCLCPP_ERROR(node_->get_logger(), "send_goal failed");
     return false;
   }
 
-  auto goal_handle = goal_handle_future.get();
-  if (!goal_handle) {
-    RCLCPP_ERROR(
-      node_->get_logger(), "ExecutorClient: Plan execution was rejected by the action server");
+  goal_handle_ = future_goal_handle.get();
+  if (!goal_handle_) {
+    RCLCPP_ERROR(node_->get_logger(), "Goal was rejected by the action server");
     return false;
   }
 
   return true;
 }
 
+bool
+ExecutorClient::should_cancel_goal()
+{
+  if (!executing_plan_) {
+    return false;
+  }
+
+  rclcpp::spin_some(node_);
+  auto status = goal_handle_->get_status();
+
+  return status == action_msgs::msg::GoalStatus::STATUS_ACCEPTED ||
+         status == action_msgs::msg::GoalStatus::STATUS_EXECUTING;
+}
+
+void
+ExecutorClient::cancel_plan_execution()
+{
+  if (should_cancel_goal()) {
+    auto future_cancel = action_client_->async_cancel_goal(goal_handle_);
+    if (rclcpp::spin_until_future_complete(
+        node_->get_node_base_interface(), future_cancel, 3s) !=
+      rclcpp::FutureReturnCode::SUCCESS)
+    {
+      RCLCPP_ERROR(
+        node_->get_logger(),
+        "Failed to cancel action server for execute_plan");
+    }
+  }
+
+  executing_plan_ = false;
+  goal_result_available_ = false;
+}
+
 void
 ExecutorClient::feedback_callback(
-  GoalHandleExecutePlan::SharedPtr,
+  GoalHandleExecutePlan::SharedPtr goal_handle,
   const std::shared_ptr<const ExecutePlan::Feedback> feedback)
 {
   feedback_ = *feedback;
@@ -92,36 +171,15 @@ ExecutorClient::feedback_callback(
 void
 ExecutorClient::result_callback(const GoalHandleExecutePlan::WrappedResult & result)
 {
-  finished_ = true;
-  result_ = *result.result;
-
-  switch (result.code) {
-    case rclcpp_action::ResultCode::SUCCEEDED:
-      break;
-    case rclcpp_action::ResultCode::ABORTED:
-      RCLCPP_ERROR(node_->get_logger(), "Goal was aborted");
-      return;
-    case rclcpp_action::ResultCode::CANCELED:
-      RCLCPP_ERROR(node_->get_logger(), "Goal was canceled");
-      return;
-    default:
-      RCLCPP_ERROR(node_->get_logger(), "Unknown result code");
-      return;
-  }
-
-  if (result.result->success) {
-    RCLCPP_INFO(node_->get_logger(), "Result received: Success");
-  } else {
-    RCLCPP_INFO(
-      node_->get_logger(), "Result received: Fail");
-  }
+  goal_result_available_ = true;
+  result_ = result;
 }
 
 std::optional<ExecutePlan::Result>
 ExecutorClient::getResult()
 {
-  if (finished_) {
-    return result_;
+  if (result_.result != nullptr) {
+    return *result_.result;
   } else {
     return {};
   }

--- a/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
+++ b/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
@@ -146,43 +146,18 @@ ExecutorNode::handle_goal(
   const rclcpp_action::GoalUUID & uuid,
   std::shared_ptr<const ExecutePlan::Goal> goal)
 {
-  auto start = now();
-  RCLCPP_INFO(this->get_logger(), "Received goal request with order");
+  RCLCPP_DEBUG(this->get_logger(), "Received goal request with order");
 
-  auto domain = domain_client_->getDomain();
-  auto problem = problem_client_->getProblem();
-
-  auto domain_problem_ts = now();
-
-  current_plan_ = planner_client_->getPlan(domain, problem);
-  auto plan_ts = now();
-
-  RCLCPP_INFO(
-    get_logger(), "Getting domain and problem = %lf secs",
-    (domain_problem_ts - start).seconds());
-
-  RCLCPP_INFO(
-    get_logger(), "Getting plan = %lf secs",
-    (plan_ts - domain_problem_ts).seconds());
-
-  if (current_plan_) {
-    std::cout << "plan: " << std::endl;
-    for (const auto & action : current_plan_.value()) {
-      std::cout << action.time << "\t" << action.action << "\t" <<
-        action.duration << std::endl;
-    }
-    return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
-  } else {
-    RCLCPP_ERROR(get_logger(), "Executor problem [Plan not found]");
-    return rclcpp_action::GoalResponse::REJECT;
-  }
+  return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
 }
 
 rclcpp_action::CancelResponse
 ExecutorNode::handle_cancel(
   const std::shared_ptr<GoalHandleExecutePlan> goal_handle)
 {
-  RCLCPP_INFO(this->get_logger(), "Received request to cancel goal");
+  RCLCPP_DEBUG(this->get_logger(), "Received request to cancel goal");
+
+  cancel_plan_requested_ = true;
 
   return rclcpp_action::CancelResponse::ACCEPT;
 }
@@ -193,9 +168,22 @@ ExecutorNode::execute(const std::shared_ptr<GoalHandleExecutePlan> goal_handle)
   auto feedback = std::make_shared<ExecutePlan::Feedback>();
   auto result = std::make_shared<ExecutePlan::Result>();
 
+  cancel_plan_requested_ = false;
+
+  auto domain = domain_client_->getDomain();
+  auto problem = problem_client_->getProblem();
+  auto current_plan = planner_client_->getPlan(domain, problem);
+
+  if (!current_plan.has_value()) {
+    RCLCPP_ERROR(get_logger(), "No plan found");
+    result->success = false;
+    goal_handle->succeed(result);
+    return;
+  }
+
   auto action_map = std::make_shared<std::map<std::string, ActionExecutionInfo>>();
 
-  for (const auto & action : current_plan_.value()) {
+  for (const auto & action : current_plan.value()) {
     auto index = action.action + ":" + std::to_string(static_cast<int>(action.time * 1000));
 
     (*action_map)[index] = ActionExecutionInfo();
@@ -222,7 +210,7 @@ ExecutorNode::execute(const std::shared_ptr<GoalHandleExecutePlan> goal_handle)
   factory.registerNodeType<ApplyAtStartEffect>("ApplyAtStartEffect");
   factory.registerNodeType<ApplyAtEndEffect>("ApplyAtEndEffect");
 
-  auto bt_xml_tree = bt_builder.get_tree(current_plan_.value());
+  auto bt_xml_tree = bt_builder.get_tree(current_plan.value());
 
   std::filesystem::path tp = std::filesystem::temp_directory_path();
   std::ofstream out(std::string("/tmp/") + get_namespace() + "/bt.xml");
@@ -265,7 +253,7 @@ ExecutorNode::execute(const std::shared_ptr<GoalHandleExecutePlan> goal_handle)
   auto start = now();
   auto status = BT::NodeStatus::RUNNING;
 
-  while (status == BT::NodeStatus::RUNNING) {
+  while (status == BT::NodeStatus::RUNNING && !cancel_plan_requested_) {
     try {
       status = tree.tickRoot();
     } catch (std::exception & e) {
@@ -279,7 +267,12 @@ ExecutorNode::execute(const std::shared_ptr<GoalHandleExecutePlan> goal_handle)
     rate.sleep();
   }
 
+  if (cancel_plan_requested_) {
+    tree.haltTree();
+  }
+
   if (status == BT::NodeStatus::FAILURE) {
+    tree.haltTree();
     RCLCPP_ERROR(get_logger(), "Executor BT finished with FAILURE state");
   }
 
@@ -298,7 +291,11 @@ ExecutorNode::execute(const std::shared_ptr<GoalHandleExecutePlan> goal_handle)
 
   if (rclcpp::ok()) {
     goal_handle->succeed(result);
-    RCLCPP_INFO(this->get_logger(), "Plan Succeeded");
+    if (result->success) {
+      RCLCPP_INFO(this->get_logger(), "Plan Succeeded");
+    } else {
+      RCLCPP_INFO(this->get_logger(), "Plan Failed");
+    }
   }
 }
 
@@ -332,6 +329,9 @@ ExecutorNode::get_feedback_info(
         break;
       case ActionExecutor::FAILURE:
         info.status = plansys2_msgs::msg::ActionExecutionInfo::FAILED;
+        break;
+      case ActionExecutor::CANCELLED:
+        info.status = plansys2_msgs::msg::ActionExecutionInfo::CANCELLED;
         break;
     }
 

--- a/plansys2_executor/src/plansys2_executor/behavior_tree/execute_action_node.cpp
+++ b/plansys2_executor/src/plansys2_executor/behavior_tree/execute_action_node.cpp
@@ -32,6 +32,20 @@ ExecuteAction::ExecuteAction(
   node_ = config().blackboard->get<rclcpp_lifecycle::LifecycleNode::SharedPtr>("node");
 }
 
+void
+ExecuteAction::halt()
+{
+  std::string action;
+  getInput("action", action);
+
+  size_t delim = action.find(":");
+  auto action_expr = action.substr(0, delim);
+
+  if ((*action_map_)[action].action_executor->get_status() == BT::NodeStatus::RUNNING) {
+    (*action_map_)[action].action_executor->cancel();
+  }
+}
+
 BT::NodeStatus
 ExecuteAction::tick()
 {

--- a/plansys2_executor/test/pddl/factory3.pddl
+++ b/plansys2_executor/test/pddl/factory3.pddl
@@ -1,0 +1,85 @@
+( define ( domain factory )
+( :requirements :strips :adl :typing :durative-actions :fluents )
+( :types
+	robot - object
+	zone - object
+	piece - object
+	car - object
+)
+( :predicates
+	( robot_available ?robot0 - robot )
+  ( battery_full ?robot0 - robot )
+	( robot_at ?robot0 - robot ?zone1 - zone )
+	( piece_at ?piece0 - piece ?zone1 - zone )
+	( piece_is_wheel ?piece0 - piece )
+	( piece_is_body_car ?piece0 - piece )
+	( piece_is_steering_wheel ?piece0 - piece )
+	( piece_not_used ?piece0 - piece )
+	( is_assembly_zone ?zone0 - zone )
+	( car_assembled ?car0 - car )
+)
+( :durative-action move
+  :parameters ( ?robot0 - robot ?zone1 - zone ?zone2 - zone )
+  :duration ( = ?duration 5 )
+  :condition
+	( and
+		( at start ( robot_available ?robot0 ) )
+		( at start ( robot_at ?robot0 ?zone1 ) )
+    ( over all ( battery_full ?robot0 ) )
+	)
+  :effect
+	( and
+		( at start ( not ( robot_at ?robot0 ?zone1 ) ) )
+		( at start ( not ( robot_available ?robot0 ) ) )
+		( at end ( robot_at ?robot0 ?zone2 ) )
+		( at end ( robot_available ?robot0 ) )
+	)
+)
+( :durative-action transport
+  :parameters ( ?robot0 - robot ?piece1 - piece ?zone2 - zone ?zone3 - zone )
+  :duration ( = ?duration 5 )
+  :condition
+	( and
+		( at start ( robot_available ?robot0 ) )
+		( at start ( robot_at ?robot0 ?zone2 ) )
+		( at start ( piece_at ?piece1 ?zone2 ) )
+	)
+  :effect
+	( and
+		( at start ( not ( robot_at ?robot0 ?zone2 ) ) )
+		( at start ( not ( piece_at ?piece1 ?zone2 ) ) )
+		( at start ( not ( robot_available ?robot0 ) ) )
+		( at end ( robot_at ?robot0 ?zone3 ) )
+		( at end ( piece_at ?piece1 ?zone3 ) )
+		( at end ( robot_available ?robot0 ) )
+	)
+)
+( :durative-action assemble
+  :parameters ( ?robot0 - robot ?zone1 - zone ?piece2 - piece ?piece3 - piece ?piece4 - piece ?car5 - car )
+  :duration ( = ?duration 5 )
+  :condition
+	( and
+		( at start ( robot_available ?robot0 ) )
+		( at start ( is_assembly_zone ?zone1 ) )
+		( at start ( robot_at ?robot0 ?zone1 ) )
+		( at start ( piece_at ?piece2 ?zone1 ) )
+		( at start ( piece_at ?piece3 ?zone1 ) )
+		( at start ( piece_at ?piece4 ?zone1 ) )
+		( at start ( piece_not_used ?piece2 ) )
+		( at start ( piece_not_used ?piece3 ) )
+		( at start ( piece_not_used ?piece4 ) )
+		( at start ( piece_is_wheel ?piece2 ) )
+		( at start ( piece_is_body_car ?piece3 ) )
+		( at start ( piece_is_steering_wheel ?piece4 ) )
+	)
+  :effect
+	( and
+		( at start ( not ( piece_not_used ?piece2 ) ) )
+		( at start ( not ( piece_not_used ?piece3 ) ) )
+		( at start ( not ( piece_not_used ?piece4 ) ) )
+		( at start ( not ( robot_available ?robot0 ) ) )
+		( at end ( car_assembled ?car5 ) )
+		( at end ( robot_available ?robot0 ) )
+	)
+)
+)

--- a/plansys2_executor/test/unit/CMakeLists.txt
+++ b/plansys2_executor/test/unit/CMakeLists.txt
@@ -2,6 +2,11 @@ ament_add_gtest(executor_test executor_test.cpp)
 target_compile_definitions(executor_test PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 target_link_libraries(executor_test ${PROJECT_NAME})
 
+ament_add_gtest(action_execution_test action_execution_test.cpp)
+target_compile_definitions(action_execution_test PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
+target_link_libraries(action_execution_test ${PROJECT_NAME})
+
+
 ament_add_gtest(execution_tree_test execution_tree_test.cpp)
 target_compile_definitions(execution_tree_test PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")
 target_link_libraries(execution_tree_test ${PROJECT_NAME})

--- a/plansys2_executor/test/unit/action_execution_test.cpp
+++ b/plansys2_executor/test/unit/action_execution_test.cpp
@@ -35,7 +35,7 @@
 #include "plansys2_executor/ActionExecutorClient.hpp"
 #include "plansys2_executor/ExecutorNode.hpp"
 #include "plansys2_executor/ExecutorClient.hpp"
-#include "plansys2_executor/Utils.hpp"
+#include "plansys2_problem_expert/Utils.hpp"
 
 #include "behaviortree_cpp_v3/behavior_tree.h"
 #include "behaviortree_cpp_v3/bt_factory.h"

--- a/plansys2_executor/test/unit/action_execution_test.cpp
+++ b/plansys2_executor/test/unit/action_execution_test.cpp
@@ -1,0 +1,356 @@
+// Copyright 2021 Intelligent Robotics Lab
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <vector>
+#include <regex>
+#include <iostream>
+#include <memory>
+#include <thread>
+#include <fstream>
+#include <map>
+
+#include "ament_index_cpp/get_package_share_directory.hpp"
+
+#include "plansys2_domain_expert/DomainExpertNode.hpp"
+#include "plansys2_domain_expert/DomainExpertClient.hpp"
+#include "plansys2_problem_expert/ProblemExpertNode.hpp"
+#include "plansys2_problem_expert/ProblemExpertClient.hpp"
+#include "plansys2_planner/PlannerNode.hpp"
+#include "plansys2_planner/PlannerClient.hpp"
+#include "plansys2_executor/BTBuilder.hpp"
+
+#include "plansys2_executor/ActionExecutor.hpp"
+#include "plansys2_executor/ActionExecutorClient.hpp"
+#include "plansys2_executor/ExecutorNode.hpp"
+#include "plansys2_executor/ExecutorClient.hpp"
+#include "plansys2_executor/Utils.hpp"
+
+#include "behaviortree_cpp_v3/behavior_tree.h"
+#include "behaviortree_cpp_v3/bt_factory.h"
+#include "behaviortree_cpp_v3/utils/shared_library.h"
+#include "behaviortree_cpp_v3/blackboard.h"
+
+#include "plansys2_executor/behavior_tree/execute_action_node.hpp"
+#include "plansys2_executor/behavior_tree/wait_action_node.hpp"
+#include "plansys2_executor/behavior_tree/wait_atstart_req_node.hpp"
+#include "plansys2_executor/behavior_tree/check_overall_req_node.hpp"
+#include "plansys2_executor/behavior_tree/check_atend_req_node.hpp"
+#include "plansys2_executor/behavior_tree/apply_atstart_effect_node.hpp"
+#include "plansys2_executor/behavior_tree/apply_atend_effect_node.hpp"
+
+#include "lifecycle_msgs/msg/state.hpp"
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_action/rclcpp_action.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+
+#include "gtest/gtest.h"
+
+
+using CallbackReturnT =
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+using namespace std::chrono_literals;
+
+class MoveAction : public plansys2::ActionExecutorClient
+{
+public:
+  using Ptr = std::shared_ptr<MoveAction>;
+  static Ptr make_shared(const std::string & node_name, const std::chrono::nanoseconds & rate)
+  {
+    return std::make_shared<MoveAction>(node_name, rate);
+  }
+
+
+  MoveAction(const std::string & id, const std::chrono::nanoseconds & rate)
+  : ActionExecutorClient(id, rate)
+  {
+    executions_ = 0;
+    cycles_ = 0;
+  }
+
+  CallbackReturnT
+  on_activate(const rclcpp_lifecycle::State & state)
+  {
+    std::cerr << "MoveAction::on_activate" << std::endl;
+    counter_ = 0;
+
+    return ActionExecutorClient::on_activate(state);
+  }
+
+  void do_work() override
+  {
+    RCLCPP_INFO_STREAM(get_logger(), "Executing [" << action_managed_ << "]");
+    for (const auto & arg : current_arguments_) {
+      RCLCPP_INFO_STREAM(get_logger(), "\t[" << arg << "]");
+    }
+
+    cycles_++;
+
+    if (counter_++ > 3) {
+      finish(true, 1.0, "completed");
+      executions_++;
+    } else {
+      send_feedback(counter_ * 0.0, "running");
+    }
+  }
+
+  int counter_;
+  int executions_;
+  int cycles_;
+};
+
+TEST(action_execution, protocol_basic)
+{
+  auto test_node = rclcpp::Node::make_shared("test_node");
+  auto test_lf_node = rclcpp_lifecycle::LifecycleNode::make_shared("test_lf_node");
+  auto move_action_node = std::make_shared<MoveAction>("move_action", 1s);
+  auto move_action_executor = plansys2::ActionExecutor::make_shared(
+    "(move r2d2 steering_wheels_zone assembly_zone)", test_lf_node);
+
+  ASSERT_EQ(move_action_executor->get_action_name(), "move");
+  ASSERT_EQ(move_action_executor->get_action_params().size(), 3u);
+  ASSERT_EQ(move_action_executor->get_action_params()[0], "r2d2");
+  ASSERT_EQ(move_action_executor->get_action_params()[2], "assembly_zone");
+
+  move_action_node->set_parameter({"action_name", "move"});
+
+  rclcpp::executors::MultiThreadedExecutor exe(rclcpp::executor::ExecutorArgs(), 8);
+
+  exe.add_node(test_node);
+  exe.add_node(test_lf_node->get_node_base_interface());
+  exe.add_node(move_action_node->get_node_base_interface());
+
+  std::vector<plansys2_msgs::msg::ActionExecution> action_execution_msgs;
+
+  auto action_hub_sub = test_node->create_subscription<plansys2_msgs::msg::ActionExecution>(
+    "/actions_hub", rclcpp::QoS(100).reliable(),
+    [&action_execution_msgs](const plansys2_msgs::msg::ActionExecution::SharedPtr msg) {
+      action_execution_msgs.push_back(*msg);
+    });
+
+  bool finish = false;
+  std::thread t([&]() {
+      while (!finish) {exe.spin_some();}
+    });
+
+  ASSERT_EQ(move_action_executor->get_internal_status(), plansys2::ActionExecutor::Status::IDLE);
+  ASSERT_EQ(
+    move_action_node->get_internal_status().state,
+    plansys2_msgs::msg::ActionPerformerStatus::NOT_READY);
+
+  test_lf_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  move_action_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = test_node->now();
+    while ((test_node->now() - start).seconds() < 0.5) {
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(
+    move_action_node->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  ASSERT_EQ(
+    move_action_node->get_internal_status().state,
+    plansys2_msgs::msg::ActionPerformerStatus::READY);
+  ASSERT_TRUE(action_execution_msgs.empty());
+
+  {
+    std::vector<BT::NodeStatus> tick_status_log;
+    rclcpp::Rate rate(10);
+    auto start = test_node->now();
+    while ((test_node->now() - start).seconds() < 0.5) {
+      tick_status_log.push_back(move_action_executor->tick(test_node->now()));
+      rate.sleep();
+    }
+    ASSERT_EQ(tick_status_log[0], BT::NodeStatus::RUNNING);
+  }
+
+  ASSERT_EQ(
+    move_action_node->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  ASSERT_EQ(move_action_executor->get_internal_status(), plansys2::ActionExecutor::Status::RUNNING);
+  ASSERT_EQ(
+    move_action_node->get_internal_status().state,
+    plansys2_msgs::msg::ActionPerformerStatus::RUNNING);
+
+  ASSERT_EQ(action_execution_msgs.size(), 3u);
+  ASSERT_EQ(action_execution_msgs[0].type, plansys2_msgs::msg::ActionExecution::REQUEST);
+  ASSERT_EQ(action_execution_msgs[1].type, plansys2_msgs::msg::ActionExecution::RESPONSE);
+  ASSERT_EQ(action_execution_msgs[2].type, plansys2_msgs::msg::ActionExecution::CONFIRM);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = test_node->now();
+    while ((test_node->now() - start).seconds() < 5) {
+      move_action_executor->tick(test_node->now());
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(move_action_executor->get_internal_status(), plansys2::ActionExecutor::Status::SUCCESS);
+  ASSERT_EQ(
+    move_action_node->get_internal_status().state,
+    plansys2_msgs::msg::ActionPerformerStatus::READY);
+
+
+  ASSERT_EQ(action_execution_msgs.size(), 8u);
+  ASSERT_EQ(action_execution_msgs[3].type, plansys2_msgs::msg::ActionExecution::FEEDBACK);
+  ASSERT_EQ(action_execution_msgs[4].type, plansys2_msgs::msg::ActionExecution::FEEDBACK);
+  ASSERT_EQ(action_execution_msgs[5].type, plansys2_msgs::msg::ActionExecution::FEEDBACK);
+  ASSERT_EQ(action_execution_msgs[6].type, plansys2_msgs::msg::ActionExecution::FEEDBACK);
+  ASSERT_EQ(action_execution_msgs[7].type, plansys2_msgs::msg::ActionExecution::FINISH);
+
+
+  ASSERT_EQ(move_action_executor->get_internal_status(), plansys2::ActionExecutor::Status::SUCCESS);
+  ASSERT_EQ(
+    move_action_node->get_internal_status().state,
+    plansys2_msgs::msg::ActionPerformerStatus::READY);
+
+  finish = true;
+  t.join();
+}
+
+TEST(action_execution, protocol_cancelation)
+{
+  auto test_node = rclcpp::Node::make_shared("test_node");
+  auto test_lf_node = rclcpp_lifecycle::LifecycleNode::make_shared("test_lf_node");
+  auto move_action_node = std::make_shared<MoveAction>("move_action", 1s);
+  auto move_action_executor = plansys2::ActionExecutor::make_shared(
+    "(move r2d2 steering_wheels_zone assembly_zone)", test_lf_node);
+
+  ASSERT_EQ(move_action_executor->get_action_name(), "move");
+  ASSERT_EQ(move_action_executor->get_action_params().size(), 3u);
+  ASSERT_EQ(move_action_executor->get_action_params()[0], "r2d2");
+  ASSERT_EQ(move_action_executor->get_action_params()[2], "assembly_zone");
+
+  move_action_node->set_parameter({"action_name", "move"});
+
+  rclcpp::executors::MultiThreadedExecutor exe(rclcpp::executor::ExecutorArgs(), 8);
+
+  exe.add_node(test_node);
+  exe.add_node(test_lf_node->get_node_base_interface());
+  exe.add_node(move_action_node->get_node_base_interface());
+
+  std::vector<plansys2_msgs::msg::ActionExecution> action_execution_msgs;
+
+  auto action_hub_sub = test_node->create_subscription<plansys2_msgs::msg::ActionExecution>(
+    "/actions_hub", rclcpp::QoS(100).reliable(),
+    [&action_execution_msgs](const plansys2_msgs::msg::ActionExecution::SharedPtr msg) {
+      action_execution_msgs.push_back(*msg);
+    });
+
+  bool finish = false;
+  std::thread t([&]() {
+      while (!finish) {exe.spin_some();}
+    });
+
+  ASSERT_EQ(move_action_executor->get_internal_status(), plansys2::ActionExecutor::Status::IDLE);
+  ASSERT_EQ(
+    move_action_node->get_internal_status().state,
+    plansys2_msgs::msg::ActionPerformerStatus::NOT_READY);
+
+  test_lf_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  move_action_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = test_node->now();
+    while ((test_node->now() - start).seconds() < 0.5) {
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(
+    move_action_node->get_current_state().id(),
+    lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+
+  ASSERT_EQ(
+    move_action_node->get_internal_status().state,
+    plansys2_msgs::msg::ActionPerformerStatus::READY);
+  ASSERT_TRUE(action_execution_msgs.empty());
+
+  {
+    std::vector<BT::NodeStatus> tick_status_log;
+    rclcpp::Rate rate(10);
+    auto start = test_node->now();
+    while ((test_node->now() - start).seconds() < 0.5) {
+      tick_status_log.push_back(move_action_executor->tick(test_node->now()));
+      rate.sleep();
+    }
+    ASSERT_EQ(tick_status_log[0], BT::NodeStatus::RUNNING);
+  }
+
+  ASSERT_EQ(
+    move_action_node->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
+
+  ASSERT_EQ(
+    move_action_executor->get_internal_status(), plansys2::ActionExecutor::Status::RUNNING);
+  ASSERT_EQ(
+    move_action_node->get_internal_status().state,
+    plansys2_msgs::msg::ActionPerformerStatus::RUNNING);
+
+  ASSERT_EQ(action_execution_msgs.size(), 3u);
+  ASSERT_EQ(action_execution_msgs[0].type, plansys2_msgs::msg::ActionExecution::REQUEST);
+  ASSERT_EQ(action_execution_msgs[1].type, plansys2_msgs::msg::ActionExecution::RESPONSE);
+  ASSERT_EQ(action_execution_msgs[2].type, plansys2_msgs::msg::ActionExecution::CONFIRM);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = test_node->now();
+    while ((test_node->now() - start).seconds() < 2) {
+      move_action_executor->tick(test_node->now());
+      rate.sleep();
+    }
+  }
+
+  move_action_executor->cancel();
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = test_node->now();
+    while ((test_node->now() - start).seconds() < 2) {
+      move_action_executor->tick(test_node->now());
+      rate.sleep();
+    }
+  }
+
+  ASSERT_EQ(
+    move_action_executor->get_internal_status(),
+    plansys2::ActionExecutor::Status::CANCELLED);
+  ASSERT_EQ(
+    move_action_node->get_internal_status().state,
+    plansys2_msgs::msg::ActionPerformerStatus::READY);
+
+
+  ASSERT_EQ(action_execution_msgs.size(), 6u);
+  ASSERT_EQ(action_execution_msgs[3].type, plansys2_msgs::msg::ActionExecution::FEEDBACK);
+  ASSERT_EQ(action_execution_msgs[4].type, plansys2_msgs::msg::ActionExecution::FEEDBACK);
+  ASSERT_EQ(action_execution_msgs[5].type, plansys2_msgs::msg::ActionExecution::CANCEL);
+
+  finish = true;
+  t.join();
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+
+  return RUN_ALL_TESTS();
+}

--- a/plansys2_executor/test/unit/executor_test.cpp
+++ b/plansys2_executor/test/unit/executor_test.cpp
@@ -35,7 +35,7 @@
 #include "plansys2_executor/ActionExecutorClient.hpp"
 #include "plansys2_executor/ExecutorNode.hpp"
 #include "plansys2_executor/ExecutorClient.hpp"
-#include "plansys2_executor/Utils.hpp"
+#include "plansys2_problem_expert/Utils.hpp"
 
 #include "behaviortree_cpp_v3/behavior_tree.h"
 #include "behaviortree_cpp_v3/bt_factory.h"

--- a/plansys2_msgs/CMakeLists.txt
+++ b/plansys2_msgs/CMakeLists.txt
@@ -34,6 +34,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/AddProblemPredicate.srv"
   "srv/AddProblemFunction.srv"
   "srv/RemoveProblemGoal.srv"
+  "srv/ClearProblemKnowledge.srv"
   "srv/RemoveProblemInstance.srv"
   "srv/RemoveProblemPredicate.srv"
   "srv/RemoveProblemFunction.srv"

--- a/plansys2_msgs/msg/ActionExecution.msg
+++ b/plansys2_msgs/msg/ActionExecution.msg
@@ -4,6 +4,7 @@ int16 CONFIRM=3
 int16 REJECT=4
 int16 FEEDBACK=5
 int16 FINISH=6
+int16 CANCEL=7
 
 int16 type
 string node_id

--- a/plansys2_msgs/msg/ActionExecutionInfo.msg
+++ b/plansys2_msgs/msg/ActionExecutionInfo.msg
@@ -2,6 +2,7 @@ int8 NOT_EXECUTED=1
 int8 EXECUTING=2
 int8 FAILED=3
 int8 SUCCEEDED=4
+int8 CANCELLED=5
 
 int8 status
 

--- a/plansys2_msgs/srv/ClearProblemKnowledge.srv
+++ b/plansys2_msgs/srv/ClearProblemKnowledge.srv
@@ -1,0 +1,4 @@
+std_msgs/Empty request
+---
+bool success
+string error_info

--- a/plansys2_problem_expert/include/plansys2_problem_expert/ProblemExpert.hpp
+++ b/plansys2_problem_expert/include/plansys2_problem_expert/ProblemExpert.hpp
@@ -53,6 +53,7 @@ public:
   parser::pddl::tree::Goal getGoal();
   bool setGoal(const parser::pddl::tree::Goal & goal);
   bool clearGoal();
+  bool clearKnowledge();
 
   std::string getProblem();
 

--- a/plansys2_problem_expert/include/plansys2_problem_expert/ProblemExpertClient.hpp
+++ b/plansys2_problem_expert/include/plansys2_problem_expert/ProblemExpertClient.hpp
@@ -35,6 +35,7 @@
 #include "plansys2_msgs/srv/get_problem_functions.hpp"
 #include "plansys2_msgs/srv/get_problem.hpp"
 #include "plansys2_msgs/srv/remove_problem_goal.hpp"
+#include "plansys2_msgs/srv/clear_problem_knowledge.hpp"
 #include "plansys2_msgs/srv/remove_problem_instance.hpp"
 #include "plansys2_msgs/srv/remove_problem_predicate.hpp"
 #include "plansys2_msgs/srv/remove_problem_function.hpp"
@@ -73,6 +74,7 @@ public:
   parser::pddl::tree::Goal getGoal();
   bool setGoal(const parser::pddl::tree::Goal & goal);
   bool clearGoal();
+  bool clearKnowledge();
 
   std::string getProblem();
 
@@ -103,6 +105,8 @@ private:
     get_problem_client_;
   rclcpp::Client<plansys2_msgs::srv::RemoveProblemGoal>::SharedPtr
     remove_problem_goal_client_;
+  rclcpp::Client<plansys2_msgs::srv::ClearProblemKnowledge>::SharedPtr
+    clear_problem_knowledge_client_;
   rclcpp::Client<plansys2_msgs::srv::RemoveProblemInstance>::SharedPtr
     remove_problem_instance_client_;
   rclcpp::Client<plansys2_msgs::srv::RemoveProblemPredicate>::SharedPtr

--- a/plansys2_problem_expert/include/plansys2_problem_expert/ProblemExpertInterface.hpp
+++ b/plansys2_problem_expert/include/plansys2_problem_expert/ProblemExpertInterface.hpp
@@ -49,6 +49,7 @@ public:
   virtual parser::pddl::tree::Goal getGoal() = 0;
   virtual bool setGoal(const parser::pddl::tree::Goal & goal) = 0;
   virtual bool clearGoal() = 0;
+  virtual bool clearKnowledge() = 0;
 
   virtual std::string getProblem() = 0;
 };

--- a/plansys2_problem_expert/include/plansys2_problem_expert/ProblemExpertNode.hpp
+++ b/plansys2_problem_expert/include/plansys2_problem_expert/ProblemExpertNode.hpp
@@ -37,6 +37,7 @@
 #include "plansys2_msgs/srv/get_problem_functions.hpp"
 #include "plansys2_msgs/srv/get_problem.hpp"
 #include "plansys2_msgs/srv/remove_problem_goal.hpp"
+#include "plansys2_msgs/srv/clear_problem_knowledge.hpp"
 #include "plansys2_msgs/srv/remove_problem_instance.hpp"
 #include "plansys2_msgs/srv/remove_problem_predicate.hpp"
 #include "plansys2_msgs/srv/remove_problem_function.hpp"
@@ -132,6 +133,11 @@ public:
     const std::shared_ptr<plansys2_msgs::srv::RemoveProblemGoal::Request> request,
     const std::shared_ptr<plansys2_msgs::srv::RemoveProblemGoal::Response> response);
 
+  void clear_problem_knowledge_service_callback(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<plansys2_msgs::srv::ClearProblemKnowledge::Request> request,
+    const std::shared_ptr<plansys2_msgs::srv::ClearProblemKnowledge::Response> response);
+
   void remove_problem_instance_service_callback(
     const std::shared_ptr<rmw_request_id_t> request_header,
     const std::shared_ptr<plansys2_msgs::srv::RemoveProblemInstance::Request> request,
@@ -191,6 +197,8 @@ private:
     get_problem_service_;
   rclcpp::Service<plansys2_msgs::srv::RemoveProblemGoal>::SharedPtr
     remove_problem_goal_service_;
+  rclcpp::Service<plansys2_msgs::srv::ClearProblemKnowledge>::SharedPtr
+    clear_problem_knowledge_service_;
   rclcpp::Service<plansys2_msgs::srv::RemoveProblemInstance>::SharedPtr
     remove_problem_instance_service_;
   rclcpp::Service<plansys2_msgs::srv::RemoveProblemPredicate>::SharedPtr

--- a/plansys2_problem_expert/src/plansys2_problem_expert/ProblemExpert.cpp
+++ b/plansys2_problem_expert/src/plansys2_problem_expert/ProblemExpert.cpp
@@ -322,6 +322,15 @@ ProblemExpert::clearGoal()
 }
 
 bool
+ProblemExpert::clearKnowledge()
+{
+  instances_.clear();
+  predicates_.clear();
+  functions_.clear();
+  return true;
+}
+
+bool
 ProblemExpert::isValidType(const std::string & type)
 {
   auto valid_types = domain_expert_->getTypes();

--- a/plansys2_problem_expert/test/unit/problem_expert_node_test.cpp
+++ b/plansys2_problem_expert/test/unit/problem_expert_node_test.cpp
@@ -213,6 +213,20 @@ TEST(problem_expert_node, addget_instances)
   ASSERT_EQ(last_knowledge_msg.predicates[1], "(robot_at r2d2 kitchen)");
   ASSERT_EQ(last_knowledge_msg.goal, "(and (robot_at r2d2 kitchen))");
 
+  ASSERT_TRUE(problem_client->clearKnowledge());
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = test_node->now();
+    while ((test_node->now() - start).seconds() < 0.5) {
+      rate.sleep();
+    }
+  }
+
+  ASSERT_TRUE(problem_client->getInstances().empty());
+  ASSERT_TRUE(problem_client->getFunctions().empty());
+  ASSERT_TRUE(problem_client->getPredicates().empty());
+
   finish = true;
   t.join();
 }

--- a/plansys2_problem_expert/test/unit/problem_expert_test.cpp
+++ b/plansys2_problem_expert/test/unit/problem_expert_test.cpp
@@ -552,6 +552,11 @@ TEST(problem_expert, get_probem)
     std::string("( :init\n\t( robot_at r2d2 bedroom )\n\t( robot_at r2d2 kitchen )\n\t( ") +
     std::string("person_at paco bedroom )\n\t( person_at paco kitchen )\n)\n( :goal\n\t( ") +
     std::string("and\n\t\t( robot_at r2d2 bedroom )\n\t\t( person_at paco kitchen )\n\t)\n)\n)\n"));
+
+  ASSERT_TRUE(problem_expert.clearKnowledge());
+  ASSERT_EQ(problem_expert.getPredicates().size(), 0);
+  ASSERT_EQ(problem_expert.getFunctions().size(), 0);
+  ASSERT_EQ(problem_expert.getInstances().size(), 0);
 }
 
 TEST(problem_expert, set_goal)


### PR DESCRIPTION
Hi all,

This week I have been working in a refactor of the executor. This solves #89 but also fixes other implementation problems.

The most important change in the API of the `ExecutoClient`. Now we have three new methods:

* `bool start_plan_execution()`: Start a execution of a new plan. It returns false if there is any problem with starting this new execution.
* `bool execute_and_check_plan()`: This method _must_ be called iteratively to refresh the result and feedback. It returns true if the plan is still executing.
* `void cancel_plan_execution()`: cancel the current plan execution.

It is a big change. I noticed that the executor was not ready to cancel the plan, and I had to include this option in messages, returned values...

Please, check it and discuss any concerns about it.

Best




Signed-off-by: Francisco Martin Rico <fmrico@gmail.com>