### PR TITLE
Publishing generated plan as a dotgraph on a string topic.

### DIFF
--- a/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
+++ b/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
@@ -48,6 +48,8 @@ struct GraphNode
   static Ptr make_shared() {return std::make_shared<GraphNode>();}
 
   ActionStamped action;
+  int node_num;
+  int level_num;
 
   std::set<std::string> predicates;
   std::map<std::string, double> functions;
@@ -62,6 +64,7 @@ struct Graph
   static Ptr make_shared() {return std::make_shared<Graph>();}
 
   std::list<GraphNode::Ptr> roots;
+  std::map<float, std::list<GraphNode::Ptr>> levels;
 };
 
 class BTBuilder
@@ -70,6 +73,7 @@ public:
   explicit BTBuilder(rclcpp::Node::SharedPtr node);
 
   std::string get_tree(const Plan & current_plan);
+  std::string get_dotgraph(const Plan & current_plan);
 
 protected:
   std::shared_ptr<plansys2::DomainExpertClient> domain_client_;
@@ -95,7 +99,8 @@ protected:
   std::list<GraphNode::Ptr> get_roots(
     std::vector<plansys2::ActionStamped> & action_sequence,
     std::set<std::string> & predicates,
-    std::map<std::string, double> & functions);
+    std::map<std::string, double> & functions,
+    int & node_counter);
   GraphNode::Ptr get_node_satisfy(
     const std::shared_ptr<parser::pddl::tree::TreeNode> requirement,
     const std::list<GraphNode::Ptr> & roots,
@@ -116,6 +121,7 @@ protected:
     GraphNode::Ptr node,
     std::list<std::string> & used_nodes,
     int level = 0);
+  std::string get_flow_dotgraph(GraphNode::Ptr node, int level = 0);
 
   std::string t(int level);
 

--- a/plansys2_executor/include/plansys2_executor/ExecutorNode.hpp
+++ b/plansys2_executor/include/plansys2_executor/ExecutorNode.hpp
@@ -30,6 +30,7 @@
 
 #include "plansys2_msgs/action/execute_plan.hpp"
 #include "plansys2_msgs/msg/action_execution_info.hpp"
+#include "std_msgs/msg/string.hpp"
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
@@ -70,6 +71,7 @@ protected:
     execution_info_pub_;
 
   rclcpp_action::Server<ExecutePlan>::SharedPtr execute_plan_action_server_;
+  rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::String>::SharedPtr dotgraph_pub_;
 
   rclcpp_action::GoalResponse handle_goal(
     const rclcpp_action::GoalUUID & uuid,

--- a/plansys2_executor/test/unit/btbuilder_tests.cpp
+++ b/plansys2_executor/test/unit/btbuilder_tests.cpp
@@ -101,9 +101,10 @@ public:
   std::list<plansys2::GraphNode::Ptr> get_roots(
     std::vector<plansys2::ActionStamped> & action_sequence,
     std::set<std::string> & predicates,
-    std::map<std::string, double> & functions)
+    std::map<std::string, double> & functions,
+    int & node_counter)
   {
-    return BTBuilder::get_roots(action_sequence, predicates, functions);
+    return BTBuilder::get_roots(action_sequence, predicates, functions, node_counter);
   }
 
   plansys2::GraphNode::Ptr get_node_satisfy(
@@ -528,7 +529,8 @@ TEST(btbuilder_tests, test_plan_2)
 
   ASSERT_EQ(action_sequence.size(), 22u);
 
-  auto roots = btbuilder->get_roots(action_sequence, predicates_set, functions_map);
+  int node_counter = 0;
+  auto roots = btbuilder->get_roots(action_sequence, predicates_set, functions_map, node_counter);
   ASSERT_EQ(roots.size(), 3u);
   // Apply roots actions
   for (auto & action_node : roots) {


### PR DESCRIPTION
Signed-off-by: Alexander Xydes <alexander.xydes@navy.mil>

Adds plan visualization via rqt plugin mentioned in #74 

*Testing*
* Basing the test off of the bt example in the ros2_planning_system_examples repository.
  * https://github.com/IntelligentRoboticsLabs/ros2_planning_system_examples/tree/master/plansys2_bt_example
* Create a workspace from this repos file: 
[plansys2-dotgraph.repos.txt](https://github.com/IntelligentRoboticsLabs/ros2_planning_system/files/6079001/plansys2-dotgraph.repos.txt)
* Terminal 1: `ros2 launch nav2_bringup tb3_simulation_launch.py`
* Terminal 2: `ros2 launch plansys2_bt_example plansys2_bt_example_launch.py`
* Terminal 3: `ros2 run rqt_dotgraph rqt_dotgraph`
* Terminal 4:
```
ros2 run plansys2_terminal plansys2_terminal
set instance r2d2 robot

set instance wheels_zone zone
set instance steering_wheels_zone zone
set instance body_car_zone zone
set instance assembly_zone zone

set instance wheel_1 piece
set instance body_car_1 piece
set instance steering_wheel_1 piece

set predicate (piece_at wheel_1 wheels_zone)
set predicate (piece_at body_car_1 body_car_zone)
set predicate (piece_at steering_wheel_1 steering_wheels_zone)

set predicate (robot_at r2d2 assembly_zone)

set goal (and(piece_at wheel_1 assembly_zone))
run
```
* After you type `run` and hit enter in Terminal 4 and the plan starts executing, you should see the plan in the rqt_dotgraph window. It should look something like this:
![plansys2-dotgraph-example](https://user-images.githubusercontent.com/42847381/109868482-852a4300-7c1c-11eb-9bdf-543165f8d539.png)


