### PR TITLE
Action result tweaks

### DIFF
--- a/plansys2_executor/src/plansys2_executor/ActionExecutor.cpp
+++ b/plansys2_executor/src/plansys2_executor/ActionExecutor.cpp
@@ -93,7 +93,7 @@ ActionExecutor::action_hub_callback(const plansys2_msgs::msg::ActionExecution::S
         }
 
         feedback_ = msg->status;
-        completion_ = 1.0;
+        completion_ = msg->completion;
 
         state_time_ = node_->now();
 

--- a/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
+++ b/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
@@ -274,10 +274,12 @@ ExecutorNode::execute(const std::shared_ptr<GoalHandleExecutePlan> goal_handle)
   if (status == BT::NodeStatus::FAILURE) {
     tree.haltTree();
     RCLCPP_ERROR(get_logger(), "Executor BT finished with FAILURE state");
+    result->success = false;
+  } else {
+    result->success = true;
   }
 
   result->action_execution_status = get_feedback_info(action_map);
-  result->success = true;
 
   size_t i = 0;
   while (i < result->action_execution_status.size() && result->success) {

--- a/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
+++ b/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
@@ -274,11 +274,9 @@ ExecutorNode::execute(const std::shared_ptr<GoalHandleExecutePlan> goal_handle)
   if (status == BT::NodeStatus::FAILURE) {
     tree.haltTree();
     RCLCPP_ERROR(get_logger(), "Executor BT finished with FAILURE state");
-    result->success = false;
-  } else {
-    result->success = true;
   }
-
+  
+  result->success = status == BT::NodeStatus::SUCCESS;
   result->action_execution_status = get_feedback_info(action_map);
 
   size_t i = 0;

--- a/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
+++ b/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
@@ -275,7 +275,7 @@ ExecutorNode::execute(const std::shared_ptr<GoalHandleExecutePlan> goal_handle)
     tree.haltTree();
     RCLCPP_ERROR(get_logger(), "Executor BT finished with FAILURE state");
   }
-  
+
   result->success = status == BT::NodeStatus::SUCCESS;
   result->action_execution_status = get_feedback_info(action_map);
 


### PR DESCRIPTION
Signed-off-by: Greg Kogut <kogut@spawar.navy.mil>

This corrects two edge cases.  One is where a BehaviorTree action return `NodeStatus::FAILURE` but does not appropriately return execution feedback status indicating failure. This can result in a plan considering the action a success and moving on to the next action.   The change assumes that a failed BT is a failed action.

Another change corrected an error where the completion percentage would be set to 1.0 on the completion of action regardless of what the actual completion percent was.    E.g. just because an action has finished probably shouldn't imply that 100% of the requested action was accomplished.  

It was not trivial to provide test instructions to test these edge cases using the usual example scenario.  However running the plansys2 tutorial example should indicate no regressions.  
