### PR TITLE
Fix typo in comment string to stop LCOV exclusion block.

### DIFF
--- a/plansys2_problem_expert/src/plansys2_problem_expert/ProblemExpert.cpp
+++ b/plansys2_problem_expert/src/plansys2_problem_expert/ProblemExpert.cpp
@@ -569,7 +569,7 @@ ProblemExpert::checkPredicateTreeTypes(
       // LCOV_EXCL_START
       std::cerr << "checkPredicateTreeTypes: Error parsing expresion [" <<
         node->toString() << "]" << std::endl;
-      // LCOV_EXCL_START
+      // LCOV_EXCL_STOP
   }
 
   return false;


### PR DESCRIPTION
Signed-off-by: Thomas Denewiler <thomas.denewiler@navy.mil>