### PR TITLE
Add check for empty pointer prior to accessing pointer. Applies to ch…

### DIFF
--- a/plansys2_problem_expert/src/plansys2_problem_expert/ProblemExpert.cpp
+++ b/plansys2_problem_expert/src/plansys2_problem_expert/ProblemExpert.cpp
@@ -495,6 +495,10 @@ ProblemExpert::checkPredicateTreeTypes(
   std::shared_ptr<parser::pddl::tree::TreeNode> node,
   std::shared_ptr<DomainExpert> & domain_expert_)
 {
+  if (!node) {
+    return false;
+  }
+
   switch (node->type_) {
     case parser::pddl::tree::AND: {
         std::shared_ptr<parser::pddl::tree::AndNode> pn_and =

--- a/plansys2_problem_expert/test/unit/problem_expert_test.cpp
+++ b/plansys2_problem_expert/test/unit/problem_expert_test.cpp
@@ -484,6 +484,21 @@ TEST(problem_expert, addget_goals)
   ASSERT_TRUE(problem_expert.setGoal(goal4));
 }
 
+TEST(problem_expert, empty_goals)
+{
+  std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_problem_expert");
+  std::ifstream domain_ifs(pkgpath + "/pddl/domain_simple.pddl");
+  std::string domain_str((
+      std::istreambuf_iterator<char>(domain_ifs)),
+    std::istreambuf_iterator<char>());
+
+  auto domain_expert = std::make_shared<plansys2::DomainExpert>(domain_str);
+  plansys2::ProblemExpert problem_expert(domain_expert);
+
+  parser::pddl::tree::Goal goal;
+  ASSERT_FALSE(problem_expert.isValidGoal(goal));
+}
+
 TEST(problem_expert, get_probem)
 {
   std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_problem_expert");


### PR DESCRIPTION
…ecking the tree types of a predicate, involved in checking if a goal is valid.

Signed-off-by: Thomas Denewiler <thomas.denewiler@navy.mil>