### PR TITLE
Get ordered sub goals

### DIFF
--- a/plansys2_executor/include/plansys2_executor/ExecutorClient.hpp
+++ b/plansys2_executor/include/plansys2_executor/ExecutorClient.hpp
@@ -18,8 +18,11 @@
 #include <optional>
 #include <string>
 #include <memory>
+#include <vector>
 
 #include "plansys2_msgs/action/execute_plan.hpp"
+#include "plansys2_msgs/srv/get_ordered_sub_goals.hpp"
+#include "plansys2_pddl_parser/Tree.h"
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
@@ -38,6 +41,7 @@ public:
   bool start_plan_execution();
   bool execute_and_check_plan();
   void cancel_plan_execution();
+  std::vector<parser::pddl::tree::Goal> getOrderedSubGoals();
 
   ExecutePlan::Feedback getFeedBack() {return feedback_;}
   std::optional<ExecutePlan::Result> getResult();
@@ -46,6 +50,8 @@ private:
   rclcpp::Node::SharedPtr node_;
 
   rclcpp_action::Client<ExecutePlan>::SharedPtr action_client_;
+  rclcpp::Client<plansys2_msgs::srv::GetOrderedSubGoals>::SharedPtr
+    get_ordered_sub_goals_client_;
 
   ExecutePlan::Goal goal_;
   ExecutePlan::Feedback feedback_;

--- a/plansys2_executor/include/plansys2_executor/ExecutorNode.hpp
+++ b/plansys2_executor/include/plansys2_executor/ExecutorNode.hpp
@@ -30,6 +30,7 @@
 
 #include "plansys2_msgs/action/execute_plan.hpp"
 #include "plansys2_msgs/msg/action_execution_info.hpp"
+#include "plansys2_msgs/srv/get_ordered_sub_goals.hpp"
 #include "std_msgs/msg/string.hpp"
 
 #include "rclcpp/rclcpp.hpp"
@@ -57,11 +58,18 @@ public:
   CallbackReturnT on_shutdown(const rclcpp_lifecycle::State & state);
   CallbackReturnT on_error(const rclcpp_lifecycle::State & state);
 
+  void get_ordered_sub_goals_service_callback(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<plansys2_msgs::srv::GetOrderedSubGoals::Request> request,
+    const std::shared_ptr<plansys2_msgs::srv::GetOrderedSubGoals::Response> response);
+
 protected:
   rclcpp::Node::SharedPtr node_;
   rclcpp::Node::SharedPtr aux_node_;
 
   bool cancel_plan_requested_;
+  std::optional<Plan> current_plan_;
+  std::optional<std::vector<parser::pddl::tree::Goal>> ordered_sub_goals_;
 
   std::shared_ptr<plansys2::DomainExpertClient> domain_client_;
   std::shared_ptr<plansys2::ProblemExpertClient> problem_client_;
@@ -71,7 +79,11 @@ protected:
     execution_info_pub_;
 
   rclcpp_action::Server<ExecutePlan>::SharedPtr execute_plan_action_server_;
+  rclcpp::Service<plansys2_msgs::srv::GetOrderedSubGoals>::SharedPtr
+    get_ordered_sub_goals_service_;
   rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::String>::SharedPtr dotgraph_pub_;
+
+  std::optional<std::vector<parser::pddl::tree::Goal>> getOrderedSubGoals();
 
   rclcpp_action::GoalResponse handle_goal(
     const rclcpp_action::GoalUUID & uuid,

--- a/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
+++ b/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
@@ -19,6 +19,7 @@
 #include <iostream>
 #include <fstream>
 #include <map>
+#include <set>
 #include <vector>
 
 #include "plansys2_executor/ExecutorNode.hpp"
@@ -73,6 +74,13 @@ ExecutorNode::ExecutorNode()
     std::bind(&ExecutorNode::handle_goal, this, _1, _2),
     std::bind(&ExecutorNode::handle_cancel, this, _1),
     std::bind(&ExecutorNode::handle_accepted, this, _1));
+
+  get_ordered_sub_goals_service_ = create_service<plansys2_msgs::srv::GetOrderedSubGoals>(
+    "executor/get_ordered_sub_goals",
+    std::bind(
+      &ExecutorNode::get_ordered_sub_goals_service_callback,
+      this, std::placeholders::_1, std::placeholders::_2,
+      std::placeholders::_3));
 }
 
 
@@ -147,12 +155,87 @@ ExecutorNode::on_error(const rclcpp_lifecycle::State & state)
   return CallbackReturnT::SUCCESS;
 }
 
+void
+ExecutorNode::get_ordered_sub_goals_service_callback(
+  const std::shared_ptr<rmw_request_id_t> request_header,
+  const std::shared_ptr<plansys2_msgs::srv::GetOrderedSubGoals::Request> request,
+  const std::shared_ptr<plansys2_msgs::srv::GetOrderedSubGoals::Response> response)
+{
+  if (ordered_sub_goals_.has_value()) {
+    for (auto goal : ordered_sub_goals_.value()) {
+      response->sub_goals.push_back(goal.toString());
+    }
+    response->success = true;
+  } else {
+    response->success = false;
+    response->error_info = "No current plan.";
+  }
+}
+
+std::optional<std::vector<parser::pddl::tree::Goal>>
+ExecutorNode::getOrderedSubGoals()
+{
+  if (!current_plan_.has_value()) {
+    return {};
+  }
+
+  parser::pddl::tree::Goal goal = problem_client_->getGoal();
+  std::vector<parser::pddl::tree::Predicate> predicates = problem_client_->getPredicates();
+  std::set<std::string> local_predicates;
+  for (auto & predicate : predicates) {
+    local_predicates.insert(predicate.toString());
+  }
+
+  std::vector<parser::pddl::tree::Function> functions = problem_client_->getFunctions();
+  std::map<std::string, double> local_functions;
+  for (auto & function : functions) {
+    local_functions.insert({function.toString(), function.value});
+  }
+
+  std::vector<parser::pddl::tree::Goal> ordered_goals;
+  std::vector<std::shared_ptr<parser::pddl::tree::TreeNode>> unordered_subgoals = get_subtrees(
+    goal.root_);
+
+  // just in case some goals are already satisfied
+  for (auto it = unordered_subgoals.begin(); it != unordered_subgoals.end(); ) {
+    if (check(*it, local_predicates, local_functions)) {
+      parser::pddl::tree::Goal new_goal("(and " + (*it)->toString() + ")");
+      ordered_goals.push_back(new_goal);
+      it = unordered_subgoals.erase(it);
+    } else {
+      ++it;
+    }
+  }
+
+  for (const auto & plan_item : current_plan_.value()) {
+    std::shared_ptr<parser::pddl::tree::DurativeAction> action = get_action_from_string(
+      plan_item.action, domain_client_);
+    apply(action->at_start_effects.root_, local_predicates, local_functions);
+    apply(action->at_end_effects.root_, local_predicates, local_functions);
+
+    for (auto it = unordered_subgoals.begin(); it != unordered_subgoals.end(); ) {
+      if (check(*it, local_predicates, local_functions)) {
+        parser::pddl::tree::Goal new_goal("(and " + (*it)->toString() + ")");
+        ordered_goals.push_back(new_goal);
+        it = unordered_subgoals.erase(it);
+      } else {
+        ++it;
+      }
+    }
+  }
+
+  return ordered_goals;
+}
+
 rclcpp_action::GoalResponse
 ExecutorNode::handle_goal(
   const rclcpp_action::GoalUUID & uuid,
   std::shared_ptr<const ExecutePlan::Goal> goal)
 {
   RCLCPP_DEBUG(this->get_logger(), "Received goal request with order");
+
+  current_plan_ = {};
+  ordered_sub_goals_ = {};
 
   return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
 }
@@ -178,9 +261,9 @@ ExecutorNode::execute(const std::shared_ptr<GoalHandleExecutePlan> goal_handle)
 
   auto domain = domain_client_->getDomain();
   auto problem = problem_client_->getProblem();
-  auto current_plan = planner_client_->getPlan(domain, problem);
+  current_plan_ = planner_client_->getPlan(domain, problem);
 
-  if (!current_plan.has_value()) {
+  if (!current_plan_.has_value()) {
     RCLCPP_ERROR(get_logger(), "No plan found");
     result->success = false;
     goal_handle->succeed(result);
@@ -189,7 +272,7 @@ ExecutorNode::execute(const std::shared_ptr<GoalHandleExecutePlan> goal_handle)
 
   auto action_map = std::make_shared<std::map<std::string, ActionExecutionInfo>>();
 
-  for (const auto & action : current_plan.value()) {
+  for (const auto & action : current_plan_.value()) {
     auto index = action.action + ":" + std::to_string(static_cast<int>(action.time * 1000));
 
     (*action_map)[index] = ActionExecutionInfo();
@@ -198,6 +281,7 @@ ExecutorNode::execute(const std::shared_ptr<GoalHandleExecutePlan> goal_handle)
     (*action_map)[index].durative_action_info =
       get_action_from_string(action.action, domain_client_);
   }
+  ordered_sub_goals_ = getOrderedSubGoals();
 
   BTBuilder bt_builder(aux_node_);
   auto blackboard = BT::Blackboard::create();
@@ -216,11 +300,11 @@ ExecutorNode::execute(const std::shared_ptr<GoalHandleExecutePlan> goal_handle)
   factory.registerNodeType<ApplyAtStartEffect>("ApplyAtStartEffect");
   factory.registerNodeType<ApplyAtEndEffect>("ApplyAtEndEffect");
 
-  auto bt_xml_tree = bt_builder.get_tree(current_plan.value());
+  auto bt_xml_tree = bt_builder.get_tree(current_plan_.value());
   std_msgs::msg::String msg;
   msg.data =
     bt_builder.get_dotgraph(
-    current_plan.value());
+    current_plan_.value());
   dotgraph_pub_->publish(msg);
 
   std::filesystem::path tp = std::filesystem::temp_directory_path();

--- a/plansys2_executor/test/unit/executor_test.cpp
+++ b/plansys2_executor/test/unit/executor_test.cpp
@@ -116,7 +116,7 @@ public:
       finish(true, 1.0, "completed");
       executions_++;
     } else {
-      send_feedback(counter_ * 0.0, "running");
+      send_feedback((counter_ / 3.0) * 100.0, "running");
     }
   }
 
@@ -1187,6 +1187,199 @@ TEST(problem_expert, executor_client_execute_plan)
   result = executor_client->getResult().value();
   for (const auto & action_status : result.action_execution_status) {
     ASSERT_EQ(action_status.status, plansys2_msgs::msg::ActionExecutionInfo::SUCCEEDED);
+  }
+
+  finish = true;
+  t.join();
+}
+
+class PatrolAction : public plansys2::ActionExecutorClient
+{
+public:
+  using Ptr = std::shared_ptr<PatrolAction>;
+  static Ptr make_shared(const std::string & node_name, const std::chrono::nanoseconds & rate)
+  {
+    return std::make_shared<PatrolAction>(node_name, rate);
+  }
+
+
+  PatrolAction(const std::string & id, const std::chrono::nanoseconds & rate)
+  : ActionExecutorClient(id, rate)
+  {
+    executions_ = 0;
+    cycles_ = 0;
+  }
+
+  CallbackReturnT
+  on_activate(const rclcpp_lifecycle::State & state)
+  {
+    std::cerr << "PatrolAction::on_activate" << std::endl;
+    counter_ = 0;
+
+    return ActionExecutorClient::on_activate(state);
+  }
+
+  void do_work() override
+  {
+    RCLCPP_INFO_STREAM(get_logger(), "Executing [" << action_managed_ << "]");
+    for (const auto & arg : current_arguments_) {
+      RCLCPP_INFO_STREAM(get_logger(), "\t[" << arg << "]");
+    }
+
+    cycles_++;
+
+    if (counter_++ > 1) {
+      finish(true, 1.0, "completed");
+      executions_++;
+    } else {
+      send_feedback((counter_ / 1.0) * 100.0, "running");
+    }
+  }
+
+  int counter_;
+  int executions_;
+  int cycles_;
+};
+
+TEST(problem_expert, executor_client_ordered_sub_goals)
+{
+  auto test_node_1 = rclcpp::Node::make_shared("test_node_1");
+  auto test_node_2 = rclcpp::Node::make_shared("test_node_2");
+  auto test_node_3 = rclcpp::Node::make_shared("test_node_3");
+  auto test_lf_node = rclcpp_lifecycle::LifecycleNode::make_shared("test_lf_node");
+  auto domain_node = std::make_shared<plansys2::DomainExpertNode>();
+  auto problem_node = std::make_shared<plansys2::ProblemExpertNode>();
+  auto planner_node = std::make_shared<plansys2::PlannerNode>();
+  auto executor_node = std::make_shared<ExecutorNodeTest>();
+
+  auto move_action_node = MoveAction::make_shared("move_action_performer", 100ms);
+  move_action_node->set_parameter({"action_name", "move"});
+
+  auto patrol_action_node = PatrolAction::make_shared("patrol_action_performer", 100ms);
+  patrol_action_node->set_parameter({"action_name", "patrol"});
+
+  auto domain_client = std::make_shared<plansys2::DomainExpertClient>(test_node_1);
+  auto problem_client = std::make_shared<plansys2::ProblemExpertClient>(test_node_1);
+  auto planner_client = std::make_shared<plansys2::PlannerClient>(test_node_2);
+  auto executor_client = std::make_shared<plansys2::ExecutorClient>(test_node_3);
+
+  std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_executor");
+
+  domain_node->set_parameter({"model_file", pkgpath + "/pddl/domain_charging.pddl"});
+  problem_node->set_parameter({"model_file", pkgpath + "/pddl/domain_charging.pddl"});
+
+  rclcpp::executors::MultiThreadedExecutor exe(rclcpp::executor::ExecutorArgs(), 9);
+
+  exe.add_node(domain_node->get_node_base_interface());
+  exe.add_node(problem_node->get_node_base_interface());
+  exe.add_node(planner_node->get_node_base_interface());
+  exe.add_node(executor_node->get_node_base_interface());
+  exe.add_node(move_action_node->get_node_base_interface());
+  exe.add_node(patrol_action_node->get_node_base_interface());
+  exe.add_node(test_lf_node->get_node_base_interface());
+
+  bool finish = false;
+  std::thread t([&]() {
+      while (!finish) {exe.spin_some();}
+    });
+
+  domain_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  problem_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  planner_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  move_action_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  patrol_action_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  test_lf_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  executor_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = test_node_1->now();
+    while ((test_node_1->now() - start).seconds() < 0.5) {
+      rate.sleep();
+    }
+  }
+
+  domain_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+  problem_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+  planner_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+  executor_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+  test_lf_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = test_node_1->now();
+    while ((test_node_1->now() - start).seconds() < 0.5) {
+      rate.sleep();
+    }
+  }
+
+  ASSERT_TRUE(problem_client->addInstance({"r2d2", "robot"}));
+  ASSERT_TRUE(problem_client->addInstance({"wp0", "waypoint"}));
+  ASSERT_TRUE(problem_client->addInstance({"wp1", "waypoint"}));
+  ASSERT_TRUE(problem_client->addInstance({"wp2", "waypoint"}));
+
+  std::vector<std::string> predicates = {
+    "(robot_at r2d2 wp0)",
+    "(connected wp0 wp1)",
+    "(connected wp1 wp0)",
+    "(connected wp0 wp2)",
+    "(connected wp2 wp0)",
+    "(connected wp1 wp2)",
+    "(connected wp2 wp1)",
+  };
+  for (const auto & pred : predicates) {
+    ASSERT_TRUE(problem_client->addPredicate(parser::pddl::tree::Predicate(pred)));
+  }
+
+  std::vector<std::string> functions = {
+    "(= (speed r2d2) 1.0)",
+    "(= (max_range r2d2) 100.0)",
+    "(= (state_of_charge r2d2) 100.0)",
+    "(= (distance wp0 wp1) 5.0)",
+    "(= (distance wp1 wp0) 5.0)",
+    "(= (distance wp0 wp2) 15.0)",
+    "(= (distance wp2 wp0) 15.0)",
+    "(= (distance wp1 wp2) 5.0)",
+    "(= (distance wp2 wp1) 5.0)",
+  };
+  for (const auto & func : functions) {
+    ASSERT_TRUE(problem_client->addFunction(parser::pddl::tree::Function(func)));
+  }
+
+  problem_client->setGoal(
+    plansys2::Goal(
+      "(and(patrolled wp1) (patrolled wp2))"));
+
+  std::vector<plansys2::Goal> expected_sub_goals = {
+    plansys2::Goal("(and(patrolled wp1))"),
+    plansys2::Goal("(and(patrolled wp2))"),
+  };
+
+  auto domain = domain_client->getDomain();
+  auto problem = problem_client->getProblem();
+  auto plan = planner_client->getPlan(domain, problem);
+  ASSERT_FALSE(domain.empty());
+  ASSERT_FALSE(problem.empty());
+  ASSERT_TRUE(plan.has_value());
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = test_node_1->now();
+
+    ASSERT_TRUE(executor_client->start_plan_execution());
+
+    while (rclcpp::ok() && executor_client->execute_and_check_plan()) {
+      auto feedback = executor_client->getFeedBack();
+
+      ASSERT_LE(feedback.action_execution_status.size(), 4);
+      rate.sleep();
+    }
+  }
+  std::vector<plansys2::Goal> actual_sub_goals = executor_client->getOrderedSubGoals();
+
+  ASSERT_EQ(actual_sub_goals.size(), expected_sub_goals.size());
+  for (size_t i = 0; i < actual_sub_goals.size(); i++) {
+    ASSERT_EQ(actual_sub_goals[i].toString(), expected_sub_goals[i].toString());
   }
 
   finish = true;

--- a/plansys2_executor/test/unit/executor_test.cpp
+++ b/plansys2_executor/test/unit/executor_test.cpp
@@ -1193,7 +1193,6 @@ TEST(problem_expert, executor_client_execute_plan)
   t.join();
 }
 
-
 TEST(problem_expert, executor_client_cancel_plan)
 {
   auto test_node_1 = rclcpp::Node::make_shared("test_node_1");

--- a/plansys2_msgs/CMakeLists.txt
+++ b/plansys2_msgs/CMakeLists.txt
@@ -21,6 +21,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/GetDomainFunctionDetails.srv"
   "srv/GetDomainActions.srv"
   "srv/GetDomainActionDetails.srv"
+  "srv/GetOrderedSubGoals.srv"
   "srv/GetProblem.srv"
   "srv/GetProblemInstances.srv"
   "srv/GetProblemInstanceDetails.srv"

--- a/plansys2_msgs/srv/GetOrderedSubGoals.srv
+++ b/plansys2_msgs/srv/GetOrderedSubGoals.srv
@@ -1,0 +1,5 @@
+std_msgs/Empty request
+---
+bool success
+string[] sub_goals
+string error_info


### PR DESCRIPTION
Add GetOrderedSubGoals service to Executor, allowing executor clients to get the order in which sub-goals will be completed by the current plan.

This will allow for things like removing a specific sub-goal if the system keeps failing to achieve that sub-goal.