### PR TITLE
Configurable Behavior Tree for actions

### DIFF
--- a/plansys2_bringup/launch/plansys2_bringup_launch_distributed.py
+++ b/plansys2_bringup/launch/plansys2_bringup_launch_distributed.py
@@ -30,7 +30,7 @@ def generate_launch_description():
     model_file = LaunchConfiguration('model_file')
     namespace = LaunchConfiguration('namespace')
     params_file = LaunchConfiguration('params_file')
-    default_action_bt_xml_filename = LaunchConfiguration('default_action_bt_xml_filename')    
+    default_action_bt_xml_filename = LaunchConfiguration('default_action_bt_xml_filename')
 
     stdout_linebuf_envvar = SetEnvironmentVariable(
         'RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED', '1')

--- a/plansys2_bringup/launch/plansys2_bringup_launch_distributed.py
+++ b/plansys2_bringup/launch/plansys2_bringup_launch_distributed.py
@@ -49,6 +49,13 @@ def generate_launch_description():
         default_value=os.path.join(bringup_dir, 'params', 'plansys2_params.yaml'),
         description='Full path to the ROS2 parameters file to use for all launched nodes')
 
+    declare_default_bt_file_cmd = DeclareLaunchArgument(
+        'default_action_bt_xml_filename',
+        default_value=os.path.join(
+          get_package_share_directory('plansys2_executor'),
+          'behavior_trees', 'plansys2_action_bt.xml'),
+        description='BT representing a PDDL action')
+
     domain_expert_cmd = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(os.path.join(
             get_package_share_directory('plansys2_domain_expert'),
@@ -106,6 +113,7 @@ def generate_launch_description():
     # Set environment variables
     ld.add_action(stdout_linebuf_envvar)
     ld.add_action(declare_model_file_cmd)
+    ld.add_action(declare_default_bt_file_cmd)
     ld.add_action(declare_namespace_cmd)
     ld.add_action(declare_params_file_cmd)
 

--- a/plansys2_bringup/launch/plansys2_bringup_launch_distributed.py
+++ b/plansys2_bringup/launch/plansys2_bringup_launch_distributed.py
@@ -30,6 +30,7 @@ def generate_launch_description():
     model_file = LaunchConfiguration('model_file')
     namespace = LaunchConfiguration('namespace')
     params_file = LaunchConfiguration('params_file')
+    default_action_bt_xml_filename = LaunchConfiguration('default_action_bt_xml_filename')    
 
     stdout_linebuf_envvar = SetEnvironmentVariable(
         'RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED', '1')
@@ -87,7 +88,8 @@ def generate_launch_description():
             'executor_launch.py')),
         launch_arguments={
           'namespace': namespace,
-          'params_file': params_file
+          'params_file': params_file,
+          'default_action_bt_xml_filename': default_action_bt_xml_filename
         }.items())
 
     lifecycle_manager_cmd = Node(

--- a/plansys2_bringup/launch/plansys2_bringup_launch_monolithic.py
+++ b/plansys2_bringup/launch/plansys2_bringup_launch_monolithic.py
@@ -25,12 +25,12 @@ from launch_ros.actions import Node
 def generate_launch_description():
     # Get the launch directory
     bringup_dir = get_package_share_directory('plansys2_bringup')
-    config_dir = os.path.join(bringup_dir, 'params')
-    config_file = os.path.join(config_dir, 'plansys2_params.yaml')
 
     # Create the launch configuration variables
     model_file = LaunchConfiguration('model_file')
     namespace = LaunchConfiguration('namespace')
+    params_file = LaunchConfiguration('params_file')
+    default_action_bt_xml_filename = LaunchConfiguration('default_action_bt_xml_filename')
 
     stdout_linebuf_envvar = SetEnvironmentVariable(
         'RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED', '1')
@@ -44,13 +44,27 @@ def generate_launch_description():
         default_value='',
         description='Namespace')
 
+    declare_params_file_cmd = DeclareLaunchArgument(
+        'params_file',
+        default_value=os.path.join(bringup_dir, 'params', 'plansys2_params.yaml'),
+        description='Full path to the ROS2 parameters file to use for all launched nodes')
+
+    declare_action_bt_xml_cmd = DeclareLaunchArgument(
+        'default_action_bt_xml_filename',
+        default_value=os.path.join(
+            get_package_share_directory('plansys2_executor'),
+            'behavior_trees', 'plansys2_action_bt.xml'),
+        description='Full path to the behavior tree xml file to use for an action')
+
     plansys2_node_cmd = Node(
         package='plansys2_bringup',
         executable='plansys2_node',
         output='screen',
         namespace=namespace,
         parameters=[
-          {'model_file': model_file},
+          {'model_file': model_file,
+           'default_action_bt_xml_filename': default_action_bt_xml_filename
+          },
           config_file
         ])
 
@@ -61,6 +75,8 @@ def generate_launch_description():
     ld.add_action(stdout_linebuf_envvar)
     ld.add_action(declare_model_file_cmd)
     ld.add_action(declare_namespace_cmd)
+    ld.add_action(declare_params_file_cmd)
+    ld.add_action(declare_action_bt_xml_cmd)
 
     # Declare the launch options
     ld.add_action(plansys2_node_cmd)

--- a/plansys2_bringup/launch/plansys2_bringup_launch_monolithic.py
+++ b/plansys2_bringup/launch/plansys2_bringup_launch_monolithic.py
@@ -49,12 +49,12 @@ def generate_launch_description():
         default_value=os.path.join(bringup_dir, 'params', 'plansys2_params.yaml'),
         description='Full path to the ROS2 parameters file to use for all launched nodes')
 
-    declare_action_bt_xml_cmd = DeclareLaunchArgument(
+    declare_default_bt_file_cmd = DeclareLaunchArgument(
         'default_action_bt_xml_filename',
         default_value=os.path.join(
-            get_package_share_directory('plansys2_executor'),
-            'behavior_trees', 'plansys2_action_bt.xml'),
-        description='Full path to the behavior tree xml file to use for an action')
+          get_package_share_directory('plansys2_executor'),
+          'behavior_trees', 'plansys2_action_bt.xml'),
+        description='BT representing a PDDL action')
 
     plansys2_node_cmd = Node(
         package='plansys2_bringup',
@@ -65,7 +65,7 @@ def generate_launch_description():
           {'model_file': model_file,
            'default_action_bt_xml_filename': default_action_bt_xml_filename
           },
-          config_file
+          params_file
         ])
 
     # Create the launch description and populate
@@ -74,9 +74,9 @@ def generate_launch_description():
     # Set environment variables
     ld.add_action(stdout_linebuf_envvar)
     ld.add_action(declare_model_file_cmd)
+    ld.add_action(declare_default_bt_file_cmd)
     ld.add_action(declare_namespace_cmd)
     ld.add_action(declare_params_file_cmd)
-    ld.add_action(declare_action_bt_xml_cmd)
 
     # Declare the launch options
     ld.add_action(plansys2_node_cmd)

--- a/plansys2_bringup/launch/plansys2_bringup_launch_monolithic.py
+++ b/plansys2_bringup/launch/plansys2_bringup_launch_monolithic.py
@@ -62,8 +62,9 @@ def generate_launch_description():
         output='screen',
         namespace=namespace,
         parameters=[
-          {'model_file': model_file,
-           'default_action_bt_xml_filename': default_action_bt_xml_filename
+          {
+            'model_file': model_file,
+            'default_action_bt_xml_filename': default_action_bt_xml_filename
           },
           params_file
         ])

--- a/plansys2_executor/CMakeLists.txt
+++ b/plansys2_executor/CMakeLists.txt
@@ -79,7 +79,7 @@ install(DIRECTORY include/
   DESTINATION include/
 )
 
-install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
+install(DIRECTORY launch behavior_trees DESTINATION share/${PROJECT_NAME})
 
 install(TARGETS
   ${PROJECT_NAME}

--- a/plansys2_executor/behavior_trees/plansys2_action_bt.xml
+++ b/plansys2_executor/behavior_trees/plansys2_action_bt.xml
@@ -1,0 +1,10 @@
+<Sequence name="ACTION_ID">
+  WAIT_AT_START_ACTIONS
+  <ApplyAtStartEffect action="ACTION_ID"/>
+  <ReactiveSequence name="ACTION_ID">
+    <CheckOverAllReq action="ACTION_ID"/>
+    <ExecuteAction action="ACTION_ID"/>
+  </ReactiveSequence>
+  <CheckAtEndReq action="ACTION_ID"/>
+  <ApplyAtEndEffect action="ACTION_ID"/>
+</Sequence>

--- a/plansys2_executor/behavior_trees/plansys2_action_bt.xml
+++ b/plansys2_executor/behavior_trees/plansys2_action_bt.xml
@@ -1,5 +1,5 @@
 <Sequence name="ACTION_ID">
-  WAIT_AT_START_ACTIONS
+WAIT_AT_START_ACTIONS
   <ApplyAtStartEffect action="ACTION_ID"/>
   <ReactiveSequence name="ACTION_ID">
     <CheckOverAllReq action="ACTION_ID"/>

--- a/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
+++ b/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
@@ -70,7 +70,7 @@ struct Graph
 class BTBuilder
 {
 public:
-  explicit BTBuilder(rclcpp::Node::SharedPtr node);
+  explicit BTBuilder(rclcpp::Node::SharedPtr node, const std::string & bt_action = "");
 
   std::string get_tree(const Plan & current_plan);
   std::string get_dotgraph(const Plan & current_plan);
@@ -78,6 +78,8 @@ public:
 protected:
   std::shared_ptr<plansys2::DomainExpertClient> domain_client_;
   std::shared_ptr<plansys2::ProblemExpertClient> problem_client_;
+
+  std::string bt_action_;
 
   void init_predicates(
     std::set<std::string> & predicates,

--- a/plansys2_executor/include/plansys2_executor/ExecutorNode.hpp
+++ b/plansys2_executor/include/plansys2_executor/ExecutorNode.hpp
@@ -71,6 +71,8 @@ protected:
   std::optional<Plan> current_plan_;
   std::optional<std::vector<parser::pddl::tree::Goal>> ordered_sub_goals_;
 
+  std::string action_bt_xml_;
+
   std::shared_ptr<plansys2::DomainExpertClient> domain_client_;
   std::shared_ptr<plansys2::ProblemExpertClient> problem_client_;
   std::shared_ptr<plansys2::PlannerClient> planner_client_;

--- a/plansys2_executor/launch/executor_launch.py
+++ b/plansys2_executor/launch/executor_launch.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
+from ament_index_python.packages import get_package_share_directory
+
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, SetEnvironmentVariable
 from launch.substitutions import LaunchConfiguration
@@ -24,11 +28,19 @@ def generate_launch_description():
 
     namespace = LaunchConfiguration('namespace')
     params_file = LaunchConfiguration('params_file')
+    default_action_bt_xml_filename = LaunchConfiguration('default_action_bt_xml_filename')
 
     declare_namespace_cmd = DeclareLaunchArgument(
         'namespace',
         default_value='',
         description='Namespace')
+
+    declare_default_bt_file_cmd = DeclareLaunchArgument(
+        'default_action_bt_xml_filename',
+        default_value=os.path.join(
+          get_package_share_directory('plansys2_executor'),
+          'behavior_trees', 'plansys2_action_bt.xml'),
+        description='BT representing a PDDL action')
 
     # Specify the actions
     executor_cmd = Node(
@@ -37,7 +49,12 @@ def generate_launch_description():
         node_name='executor',
         namespace=namespace,
         output='screen',
-        parameters=[params_file])
+        parameters=[
+          {
+            'default_action_bt_xml_filename': default_action_bt_xml_filename
+          },
+          params_file
+        ])
 
     # Create the launch description and populate
     ld = LaunchDescription()
@@ -45,6 +62,7 @@ def generate_launch_description():
     # Set environment variables
     ld.add_action(stdout_linebuf_envvar)
     ld.add_action(declare_namespace_cmd)
+    ld.add_action(declare_default_bt_file_cmd)
 
     # Declare the launch options
     ld.add_action(executor_cmd)

--- a/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
+++ b/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
@@ -38,6 +38,9 @@ BTBuilder::BTBuilder(
 {
   domain_client_ = std::make_shared<plansys2::DomainExpertClient>(node);
   problem_client_ = std::make_shared<plansys2::ProblemExpertClient>(node);
+
+  std::string action_bt_xml_filename =
+    get_parameter("default_action_bt_xml_filename").get_value<std::string>();
 }
 
 void
@@ -500,6 +503,10 @@ BTBuilder::get_graph(const Plan & current_plan)
     remove_existing_requirements(at_start_requirements, predicates, functions);
     remove_existing_requirements(over_all_requirements, predicates, functions);
     remove_existing_requirements(at_end_requirements, predicates, functions);
+
+    for (const auto & req : at_start_requirements) {
+      std::cerr << "===> [" << req->toString() << "]" << std::endl;
+    }
 
     assert(at_start_requirements.empty());
     assert(over_all_requirements.empty());

--- a/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
+++ b/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
@@ -43,7 +43,8 @@ BTBuilder::BTBuilder(
   if (bt_action != "") {
     bt_action_ = bt_action;
   } else {
-    bt_action_ = R""""(<Sequence name="ACTION_ID">
+    bt_action_ =
+      R""""(<Sequence name="ACTION_ID">
 WAIT_AT_START_ACTIONS
   <ApplyAtStartEffect action="ACTION_ID"/>
   <ReactiveSequence name="ACTION_ID">
@@ -730,10 +731,10 @@ BTBuilder::t(int level)
   return ret;
 }
 
-void replace(std::string& str, const std::string& from, const std::string& to) {
-  
+void replace(std::string& str, const std::string& from, const std::string& to)
+{  
   size_t start_pos = std::string::npos;
-  while((start_pos = str.find(from)) != std::string::npos) {
+  while ((start_pos = str.find(from)) != std::string::npos) {
     str.replace(start_pos, from.length(), to);
   }
 }

--- a/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
+++ b/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
@@ -731,8 +731,8 @@ BTBuilder::t(int level)
   return ret;
 }
 
-void replace(std::string& str, const std::string& from, const std::string& to)
-{  
+void replace(std::string & str, const std::string & from, const std::string & to)
+{
   size_t start_pos = std::string::npos;
   while ((start_pos = str.find(from)) != std::string::npos) {
     str.replace(start_pos, from.length(), to);

--- a/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
+++ b/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
@@ -34,13 +34,27 @@ namespace plansys2
 {
 
 BTBuilder::BTBuilder(
-  rclcpp::Node::SharedPtr node)
+  rclcpp::Node::SharedPtr node,
+  const std::string & bt_action)
 {
   domain_client_ = std::make_shared<plansys2::DomainExpertClient>(node);
   problem_client_ = std::make_shared<plansys2::ProblemExpertClient>(node);
 
-  std::string action_bt_xml_filename =
-    get_parameter("default_action_bt_xml_filename").get_value<std::string>();
+  if (bt_action != "") {
+    bt_action_ = bt_action;
+  } else {
+    bt_action_ = R""""(<Sequence name="ACTION_ID">
+WAIT_AT_START_ACTIONS
+  <ApplyAtStartEffect action="ACTION_ID"/>
+  <ReactiveSequence name="ACTION_ID">
+    <CheckOverAllReq action="ACTION_ID"/>
+    <ExecuteAction action="ACTION_ID"/>
+  </ReactiveSequence>
+  <CheckAtEndReq action="ACTION_ID"/>
+  <ApplyAtEndEffect action="ACTION_ID"/>
+</Sequence>
+)"""";
+  }
 }
 
 void
@@ -716,31 +730,46 @@ BTBuilder::t(int level)
   return ret;
 }
 
+void replace(std::string& str, const std::string& from, const std::string& to) {
+  
+  size_t start_pos = std::string::npos;
+  while((start_pos = str.find(from)) != std::string::npos) {
+    str.replace(start_pos, from.length(), to);
+  }
+}
+
 std::string
 BTBuilder::execution_block(const GraphNode::Ptr & node, int l)
 {
   const auto & action = node->action;
   std::string ret;
+  std::string ret_aux = bt_action_;
   const std::string action_id = "(" + action.action->name_actions_to_string() + "):" +
     std::to_string(static_cast<int>(action.time * 1000));
 
-  ret = ret + t(l) + "<Sequence name=\"" + action_id + "\">\n";
 
+  std::string wait_actions;
   for (const auto & previous_node : node->in_arcs) {
     const std::string parent_action_id = "(" +
       previous_node->action.action->name_actions_to_string() + "):" +
       std::to_string(static_cast<int>( previous_node->action.time * 1000));
-    ret = ret + t(l + 1) + "<WaitAtStartReq action=\"" + parent_action_id + "\"/>\n";
+    wait_actions = wait_actions + t(1) + "<WaitAtStartReq action=\"" + parent_action_id + "\"/>";
+
+    if (previous_node != *node->in_arcs.rbegin()) {
+      wait_actions = wait_actions + "\n";
+    }
   }
 
-  ret = ret + t(l + 1) + "<ApplyAtStartEffect action=\"" + action_id + "\"/>\n";
-  ret = ret + t(l + 1) + "<ReactiveSequence name=\"" + action_id + "\">\n";
-  ret = ret + t(l + 2) + "<CheckOverAllReq action=\"" + action_id + "\"/>\n";
-  ret = ret + t(l + 2) + "<ExecuteAction action=\"" + action_id + "\"/>\n";
-  ret = ret + t(l + 1) + "</ReactiveSequence>\n";
-  ret = ret + t(l + 1) + "<CheckAtEndReq action=\"" + action_id + "\"/>\n";
-  ret = ret + t(l + 1) + "<ApplyAtEndEffect action=\"" + action_id + "\"/>\n";
-  ret = ret + t(l) + "</Sequence>\n";
+  replace(ret_aux, "ACTION_ID", action_id);
+  replace(ret_aux, "WAIT_AT_START_ACTIONS", wait_actions);
+
+  std::istringstream f(ret_aux);
+  std::string line;
+  while (std::getline(f, line)) {
+    if (line != "") {
+      ret = ret + t(l) + line + "\n";
+    }
+  }
   return ret;
 }
 

--- a/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
+++ b/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
@@ -111,7 +111,7 @@ ExecutorNode::on_configure(const rclcpp_lifecycle::State & state)
 
   action_bt_xml_.assign(
     std::istreambuf_iterator<char>(ifs), std::istreambuf_iterator<char>());
-  
+
   dotgraph_pub_ = this->create_publisher<std_msgs::msg::String>("dot_graph", 1);
 
   aux_node_ = std::make_shared<rclcpp::Node>("executor_helper");

--- a/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
+++ b/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
@@ -58,6 +58,8 @@ ExecutorNode::ExecutorNode()
 {
   using namespace std::placeholders;
 
+  declare_parameter("default_action_bt_xml_filename");
+
 #ifdef ZMQ_FOUND
   this->declare_parameter<bool>("enable_groot_monitoring", true);
   this->declare_parameter<int>("publisher_port", 2666);

--- a/plansys2_terminal/test/terminal_test.cpp
+++ b/plansys2_terminal/test/terminal_test.cpp
@@ -277,7 +277,7 @@ TEST_F(TerminalTestCase, load_popf_plugin)
     terminal_node->process_command(command, os);
     ASSERT_TRUE(terminal_node->method_executed_["process_command"]);
     ASSERT_TRUE(terminal_node->method_executed_["process_set_instance"]);
-    ASSERT_TRUE(os.str().empty());
+    ASSERT_EQ(os.str(), "");
 
     auto ins_1 = problem_client->getInstance("leia");
     ASSERT_TRUE(ins_1.has_value());


### PR DESCRIPTION
Dear PlanSys2 developers

When building the BT that codes the plan, the generation of the last part, corresponding to the actions, is hardcoded. 

In #110, @jjzapf proposed a PR related to add QoS functionality to the actions, and we started to discuss that maybe a clean solution is set up this action BT. This PR is the first step for this solution.

In this PR, we can configure the action BT in a separate file. By default, the action BT is in the `behavior_trees` folder in `plansys2_executor`, and contains:

```
<Sequence name="ACTION_ID">
WAIT_AT_START_ACTIONS
  <ApplyAtStartEffect action="ACTION_ID"/>
  <ReactiveSequence name="ACTION_ID">
    <CheckOverAllReq action="ACTION_ID"/>
    <ExecuteAction action="ACTION_ID"/>
  </ReactiveSequence>
  <CheckAtEndReq action="ACTION_ID"/>
  <ApplyAtEndEffect action="ACTION_ID"/>
</Sequence>
```

Now you can select an alternative action BT, adding custom BT nodes that you can implement in the same way the other BT nodes (`ApplyAtStartEffect`, `CheckAtEndReq` and so on). 

It is important to respect some rules in your custom action BT:
1. It should be a sequence `<Sequence name="ACTION_ID">`
2. Every BT node has an `action="ACTION_ID"/` property to refer to the internal structures correctly.
3. `WAIT_AT_START_ACTIONS` must be the first element to guarantee the correct execution of the tree.

I hope it helps!!