### PR TITLE
Adding action execution status (as color changes) to the plan dotgraph.

### DIFF
--- a/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
+++ b/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
@@ -27,6 +27,7 @@
 
 #include "plansys2_domain_expert/DomainExpertClient.hpp"
 #include "plansys2_problem_expert/ProblemExpertClient.hpp"
+#include "plansys2_executor/ActionExecutor.hpp"
 #include "plansys2_core/Types.hpp"
 #include "plansys2_pddl_parser/Tree.h"
 
@@ -72,8 +73,12 @@ class BTBuilder
 public:
   explicit BTBuilder(rclcpp::Node::SharedPtr node);
 
+  Graph::Ptr get_graph(const Plan & current_plan);
   std::string get_tree(const Plan & current_plan);
-  std::string get_dotgraph(const Plan & current_plan);
+  std::string get_dotgraph(
+    Graph::Ptr action_graph, std::shared_ptr<std::map<std::string,
+    ActionExecutionInfo>> action_map, bool enable_legend = false,
+    bool enable_print_graph = false);
 
 protected:
   std::shared_ptr<plansys2::DomainExpertClient> domain_client_;
@@ -96,7 +101,6 @@ protected:
     std::map<std::string, double> & functions) const;
   std::pair<std::string, parser::pddl::tree::NodeType> get_base(
     const std::shared_ptr<parser::pddl::tree::TreeNode> tree_node);
-  Graph::Ptr get_graph(const Plan & current_plan);
   std::list<GraphNode::Ptr> get_roots(
     std::vector<plansys2::ActionStamped> & action_sequence,
     std::set<std::string> & predicates,
@@ -123,6 +127,15 @@ protected:
     std::list<std::string> & used_nodes,
     int level = 0);
   std::string get_flow_dotgraph(GraphNode::Ptr node, int level = 0);
+  std::string get_node_dotgraph(
+    GraphNode::Ptr node, std::shared_ptr<std::map<std::string,
+    ActionExecutionInfo>> action_map, int level = 0);
+  ActionExecutor::Status get_action_status(
+    std::shared_ptr<parser::pddl::tree::DurativeAction> action,
+    std::shared_ptr<std::map<std::string, ActionExecutionInfo>> action_map);
+  void addDotGraphLegend(
+    std::stringstream & ss, int tab_level, int level_counter,
+    int node_counter);
 
   std::string t(int level);
 

--- a/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
+++ b/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
@@ -58,6 +58,9 @@ ExecutorNode::ExecutorNode()
 {
   using namespace std::placeholders;
 
+  this->declare_parameter<bool>("enable_dotgraph_legend", true);
+  this->declare_parameter<bool>("print_graph", false);
+
 #ifdef ZMQ_FOUND
   this->declare_parameter<bool>("enable_groot_monitoring", true);
   this->declare_parameter<int>("publisher_port", 2666);
@@ -301,11 +304,13 @@ ExecutorNode::execute(const std::shared_ptr<GoalHandleExecutePlan> goal_handle)
   factory.registerNodeType<ApplyAtEndEffect>("ApplyAtEndEffect");
 
   auto bt_xml_tree = bt_builder.get_tree(current_plan_.value());
-  std_msgs::msg::String msg;
-  msg.data =
+  auto action_graph = bt_builder.get_graph(current_plan_.value());
+  std_msgs::msg::String dotgraph_msg;
+  dotgraph_msg.data =
     bt_builder.get_dotgraph(
-    current_plan_.value());
-  dotgraph_pub_->publish(msg);
+    action_graph, action_map, this->get_parameter(
+      "enable_dotgraph_legend").as_bool(), this->get_parameter("print_graph").as_bool());
+  dotgraph_pub_->publish(dotgraph_msg);
 
   std::filesystem::path tp = std::filesystem::temp_directory_path();
   std::ofstream out(std::string("/tmp/") + get_namespace() + "/bt.xml");
@@ -359,6 +364,12 @@ ExecutorNode::execute(const std::shared_ptr<GoalHandleExecutePlan> goal_handle)
     feedback->action_execution_status = get_feedback_info(action_map);
     goal_handle->publish_feedback(feedback);
 
+    dotgraph_msg.data =
+      bt_builder.get_dotgraph(
+      action_graph, action_map, this->get_parameter(
+        "enable_dotgraph_legend").as_bool());
+    dotgraph_pub_->publish(dotgraph_msg);
+
     rate.sleep();
   }
 
@@ -370,6 +381,12 @@ ExecutorNode::execute(const std::shared_ptr<GoalHandleExecutePlan> goal_handle)
     tree.haltTree();
     RCLCPP_ERROR(get_logger(), "Executor BT finished with FAILURE state");
   }
+
+  dotgraph_msg.data =
+    bt_builder.get_dotgraph(
+    action_graph, action_map, this->get_parameter(
+      "enable_dotgraph_legend").as_bool());
+  dotgraph_pub_->publish(dotgraph_msg);
 
   result->success = status == BT::NodeStatus::SUCCESS;
   result->action_execution_status = get_feedback_info(action_map);


### PR DESCRIPTION
Adding legend to plan dotgraph, adding node params for dotgraph legend and printing plan graph to terminal.

Signed-off-by: Alexander Xydes <alexander.xydes@navy.mil>

*Testing*
* Basing the test off of the bt example in the ros2_planning_system_examples repository.
  * https://github.com/IntelligentRoboticsLabs/ros2_planning_system_examples/tree/master/plansys2_bt_example
* Create a workspace from this repos file: 
[plansys2-dotgraph-action-status.repos.txt](https://github.com/IntelligentRoboticsLabs/ros2_planning_system/files/6314367/plansys2-dotgraph-action-status.repos.txt)
* Terminal 1: `ros2 launch nav2_bringup tb3_simulation_launch.py`
* Terminal 2: `ros2 launch plansys2_bt_example plansys2_bt_example_launch.py`
* Terminal 3: `ros2 run rqt_dotgraph rqt_dotgraph`
* Terminal 4:
```
ros2 run plansys2_terminal plansys2_terminal
set instance r2d2 robot

set instance wheels_zone zone
set instance steering_wheels_zone zone
set instance body_car_zone zone
set instance assembly_zone zone

set instance wheel_1 piece
set instance body_car_1 piece
set instance steering_wheel_1 piece

set predicate (piece_at wheel_1 wheels_zone)
set predicate (piece_at body_car_1 body_car_zone)
set predicate (piece_at steering_wheel_1 steering_wheels_zone)

set predicate (robot_at r2d2 assembly_zone)

set goal (and(piece_at wheel_1 assembly_zone))
run
```
* After you type `run` and hit enter in Terminal 4 and the plan starts executing, you should see the plan in the rqt_dotgraph window. It should look something like this:
![dotgraph-action-status](https://user-images.githubusercontent.com/42847381/114795743-2c35ea80-9d44-11eb-8205-6978d933b8a5.png)

