### PR TITLE
Making TFD plugin type match popf.

### DIFF
--- a/plansys2_bringup/params/plansys2_params.yaml
+++ b/plansys2_bringup/params/plansys2_params.yaml
@@ -4,4 +4,4 @@ planner:
     POPF:
       plugin: "plansys2/POPFPlanSolver"
     TFD:
-      plugin: "plansys2::TFDPlanSolver"
+      plugin: "plansys2/TFDPlanSolver"


### PR DESCRIPTION
Signed-off-by: Alexander Xydes <alexander.xydes@navy.mil>

Based on this commit: https://github.com/IntelligentRoboticsLabs/ros2_planning_system/commit/f5478d3370ce4f54b6e7f2a4c9fdffac6180461f

and testing by switching the popf type to use `::` (which failed). I think the TFD plugin type should use a slash.