### PR TITLE
Fix error when an array is empty in params

### DIFF
--- a/plansys2_bringup/params/plansys2_params.yaml
+++ b/plansys2_bringup/params/plansys2_params.yaml
@@ -5,8 +5,3 @@ planner:
       plugin: "plansys2/POPFPlanSolver"
     TFD:
       plugin: "plansys2/TFDPlanSolver"
-
-executor:
-  ros__parameters:
-    action_timeouts:
-      actions: []


### PR DESCRIPTION
Dear PlanSy2 developers,

I have just fixed a bug that made the nodes fail when launched with any launcher. Probably it is the reason for bug in issues #121 and #113 

It seems that if you set an array parameter with no values, all the nodes that read the YAML crash. The params can't be empty:
```
executor:
  ros__parameters:
    action_timeouts:
      actions: []
```

but you can use it with values:

``` 
executor:
  ros__parameters:
    action_timeouts:
      actions: ["move"]
      move:
        duration_overrun_percentage: 20.0
``` 

Best

Signed-off-by: Francisco Martín Rico <fmrico@gmail.com>