### PR TITLE
Pass plan to executor

### DIFF
--- a/plansys2_core/include/plansys2_core/PlanSolverBase.hpp
+++ b/plansys2_core/include/plansys2_core/PlanSolverBase.hpp
@@ -19,7 +19,7 @@
 #include <string>
 #include <memory>
 
-#include "plansys2_core/Types.hpp"
+#include "plansys2_msgs/msg/plan.hpp"
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
@@ -36,7 +36,7 @@ public:
 
   virtual void configure(rclcpp_lifecycle::LifecycleNode::SharedPtr &, const std::string &) {}
 
-  virtual std::optional<Plan> getPlan(
+  virtual std::optional<plansys2_msgs::msg::Plan> getPlan(
     const std::string & domain, const std::string & problem,
     const std::string & node_namespace = "") = 0;
 };

--- a/plansys2_core/include/plansys2_core/Types.hpp
+++ b/plansys2_core/include/plansys2_core/Types.hpp
@@ -27,15 +27,6 @@
 namespace plansys2
 {
 
-struct PlanItem
-{
-  float time;
-  std::string action;
-  float duration;
-};
-
-typedef std::vector<PlanItem> Plan;
-
 class Instance : public plansys2_msgs::msg::Param
 {
 public:

--- a/plansys2_executor/CMakeLists.txt
+++ b/plansys2_executor/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(rclcpp_lifecycle REQUIRED)
 find_package(lifecycle_msgs REQUIRED)
 find_package(rclcpp_cascade_lifecycle REQUIRED)
 find_package(ament_index_cpp REQUIRED)
+find_package(plansys2_core REQUIRED)
 find_package(plansys2_pddl_parser REQUIRED)
 find_package(plansys2_msgs REQUIRED)
 find_package(plansys2_domain_expert REQUIRED)
@@ -39,6 +40,7 @@ set(dependencies
     rclcpp_action
     plansys2_pddl_parser
     ament_index_cpp
+    plansys2_core
     plansys2_msgs
     plansys2_domain_expert
     plansys2_problem_expert

--- a/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
+++ b/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
@@ -30,6 +30,7 @@
 #include "plansys2_executor/ActionExecutor.hpp"
 #include "plansys2_core/Types.hpp"
 #include "plansys2_msgs/msg/durative_action.hpp"
+#include "plansys2_msgs/msg/plan.hpp"
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
@@ -74,8 +75,8 @@ class BTBuilder
 public:
   explicit BTBuilder(rclcpp::Node::SharedPtr node, const std::string & bt_action = "");
 
-  Graph::Ptr get_graph(const Plan & current_plan);
-  std::string get_tree(const Plan & current_plan);
+  Graph::Ptr get_graph(const plansys2_msgs::msg::Plan & current_plan);
+  std::string get_tree(const plansys2_msgs::msg::Plan & current_plan);
   std::string get_dotgraph(
     Graph::Ptr action_graph, std::shared_ptr<std::map<std::string,
     ActionExecutionInfo>> action_map, bool enable_legend = false,
@@ -87,7 +88,7 @@ protected:
 
   std::string bt_action_;
 
-  std::vector<ActionStamped> get_plan_actions(const Plan & plan);
+  std::vector<ActionStamped> get_plan_actions(const plansys2_msgs::msg::Plan & plan);
   void prune_backwards(GraphNode::Ptr new_node, GraphNode::Ptr node_satisfy);
   void prune_forward(GraphNode::Ptr current, std::list<GraphNode::Ptr> & used_nodes);
 

--- a/plansys2_executor/include/plansys2_executor/ExecutorClient.hpp
+++ b/plansys2_executor/include/plansys2_executor/ExecutorClient.hpp
@@ -22,6 +22,8 @@
 
 #include "plansys2_msgs/action/execute_plan.hpp"
 #include "plansys2_msgs/srv/get_ordered_sub_goals.hpp"
+#include "plansys2_msgs/srv/get_plan.hpp"
+#include "plansys2_msgs/msg/plan.hpp"
 #include "plansys2_msgs/msg/tree.hpp"
 
 #include "rclcpp/rclcpp.hpp"
@@ -38,10 +40,11 @@ public:
 
   explicit ExecutorClient(rclcpp::Node::SharedPtr provided_node);
 
-  bool start_plan_execution();
+  bool start_plan_execution(const plansys2_msgs::msg::Plan & plan);
   bool execute_and_check_plan();
   void cancel_plan_execution();
   std::vector<plansys2_msgs::msg::Tree> getOrderedSubGoals();
+  std::optional<plansys2_msgs::msg::Plan> getPlan();
 
   ExecutePlan::Feedback getFeedBack() {return feedback_;}
   std::optional<ExecutePlan::Result> getResult();
@@ -52,8 +55,8 @@ private:
   rclcpp_action::Client<ExecutePlan>::SharedPtr action_client_;
   rclcpp::Client<plansys2_msgs::srv::GetOrderedSubGoals>::SharedPtr
     get_ordered_sub_goals_client_;
+  rclcpp::Client<plansys2_msgs::srv::GetPlan>::SharedPtr get_plan_client_;
 
-  ExecutePlan::Goal goal_;
   ExecutePlan::Feedback feedback_;
   rclcpp_action::ClientGoalHandle<ExecutePlan>::SharedPtr goal_handle_;
   rclcpp_action::ClientGoalHandle<ExecutePlan>::WrappedResult result_;
@@ -67,7 +70,7 @@ private:
     GoalHandleExecutePlan::SharedPtr goal_handle,
     const std::shared_ptr<const ExecutePlan::Feedback> feedback);
 
-  bool on_new_goal_received();
+  bool on_new_goal_received(const plansys2_msgs::msg::Plan & plan);
   bool should_cancel_goal();
   void createActionClient();
 };

--- a/plansys2_executor/include/plansys2_executor/ExecutorNode.hpp
+++ b/plansys2_executor/include/plansys2_executor/ExecutorNode.hpp
@@ -63,12 +63,17 @@ public:
     const std::shared_ptr<plansys2_msgs::srv::GetOrderedSubGoals::Request> request,
     const std::shared_ptr<plansys2_msgs::srv::GetOrderedSubGoals::Response> response);
 
+  void get_plan_service_callback(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<plansys2_msgs::srv::GetPlan::Request> request,
+    const std::shared_ptr<plansys2_msgs::srv::GetPlan::Response> response);
+
 protected:
   rclcpp::Node::SharedPtr node_;
   rclcpp::Node::SharedPtr aux_node_;
 
   bool cancel_plan_requested_;
-  std::optional<Plan> current_plan_;
+  std::optional<plansys2_msgs::msg::Plan> current_plan_;
   std::optional<std::vector<plansys2_msgs::msg::Tree>> ordered_sub_goals_;
 
   std::string action_bt_xml_;
@@ -86,6 +91,8 @@ protected:
   rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::String>::SharedPtr dotgraph_pub_;
 
   std::optional<std::vector<plansys2_msgs::msg::Tree>> getOrderedSubGoals();
+
+  rclcpp::Service<plansys2_msgs::srv::GetPlan>::SharedPtr get_plan_service_;
 
   rclcpp_action::GoalResponse handle_goal(
     const rclcpp_action::GoalUUID & uuid,

--- a/plansys2_executor/package.xml
+++ b/plansys2_executor/package.xml
@@ -18,6 +18,7 @@
   <depend>lifecycle_msgs</depend>
   <depend>rclcpp_cascade_lifecycle</depend>
   <depend>ament_index_cpp</depend>
+  <depend>plansys2_core</depend>
   <depend>plansys2_pddl_parser</depend>
   <depend>plansys2_msgs</depend>
   <depend>plansys2_domain_expert</depend>

--- a/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
+++ b/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
@@ -343,7 +343,7 @@ BTBuilder::prune_forward(GraphNode::Ptr current, std::list<GraphNode::Ptr> & use
 }
 
 Graph::Ptr
-BTBuilder::get_graph(const Plan & current_plan)
+BTBuilder::get_graph(const plansys2_msgs::msg::Plan & current_plan)
 {
   int node_counter = 0;
   int level_counter = 0;
@@ -533,7 +533,7 @@ BTBuilder::get_graph(const Plan & current_plan)
 }
 
 std::string
-BTBuilder::get_tree(const Plan & current_plan)
+BTBuilder::get_tree(const plansys2_msgs::msg::Plan & current_plan)
 {
   auto action_graph = get_graph(current_plan);
 
@@ -882,11 +882,11 @@ BTBuilder::execution_block(const GraphNode::Ptr & node, int l)
 }
 
 std::vector<ActionStamped>
-BTBuilder::get_plan_actions(const Plan & plan)
+BTBuilder::get_plan_actions(const plansys2_msgs::msg::Plan & plan)
 {
   std::vector<ActionStamped> ret;
 
-  for (auto & item : plan) {
+  for (auto & item : plan.items) {
     ActionStamped action_stamped;
 
     action_stamped.time = item.time;

--- a/plansys2_executor/src/plansys2_executor/ExecutorClient.cpp
+++ b/plansys2_executor/src/plansys2_executor/ExecutorClient.cpp
@@ -35,6 +35,7 @@ ExecutorClient::ExecutorClient(rclcpp::Node::SharedPtr provided_node)
 
   get_ordered_sub_goals_client_ = node_->create_client<plansys2_msgs::srv::GetOrderedSubGoals>(
     "executor/get_ordered_sub_goals");
+  get_plan_client_ = node_->create_client<plansys2_msgs::srv::GetPlan>("executor/get_plan");
 }
 
 void
@@ -48,11 +49,11 @@ ExecutorClient::createActionClient()
 }
 
 bool
-ExecutorClient::start_plan_execution()
+ExecutorClient::start_plan_execution(const plansys2_msgs::msg::Plan & plan)
 {
   if (!executing_plan_) {
     createActionClient();
-    auto success = on_new_goal_received();
+    auto success = on_new_goal_received(plan);
 
     if (success) {
       executing_plan_ = true;
@@ -105,8 +106,11 @@ ExecutorClient::execute_and_check_plan()
 
 
 bool
-ExecutorClient::on_new_goal_received()
+ExecutorClient::on_new_goal_received(const plansys2_msgs::msg::Plan & plan)
 {
+  auto goal = ExecutePlan::Goal();
+  goal.plan = plan;
+
   auto send_goal_options = rclcpp_action::Client<ExecutePlan>::SendGoalOptions();
 
   send_goal_options.feedback_callback =
@@ -115,7 +119,7 @@ ExecutorClient::on_new_goal_received()
   send_goal_options.result_callback =
     std::bind(&ExecutorClient::result_callback, this, _1);
 
-  auto future_goal_handle = action_client_->async_send_goal(goal_, send_goal_options);
+  auto future_goal_handle = action_client_->async_send_goal(goal, send_goal_options);
 
   if (rclcpp::spin_until_future_complete(
       node_->get_node_base_interface(), future_goal_handle, 3s) !=
@@ -201,6 +205,39 @@ std::vector<plansys2_msgs::msg::Tree> ExecutorClient::getOrderedSubGoals()
   }
 
   return ret;
+}
+
+std::optional<plansys2_msgs::msg::Plan> ExecutorClient::getPlan()
+{
+  while (!get_plan_client_->wait_for_service(std::chrono::seconds(5))) {
+    if (!rclcpp::ok()) {
+      return {};
+    }
+    RCLCPP_ERROR_STREAM(
+      node_->get_logger(),
+      get_plan_client_->get_service_name() <<
+        " service  client: waiting for service to appear...");
+  }
+
+  auto request = std::make_shared<plansys2_msgs::srv::GetPlan::Request>();
+
+  auto future_result = get_plan_client_->async_send_request(request);
+
+  if (rclcpp::spin_until_future_complete(node_, future_result, std::chrono::seconds(1)) !=
+    rclcpp::executor::FutureReturnCode::SUCCESS)
+  {
+    return {};
+  }
+
+  if (future_result.get()->success) {
+    return future_result.get()->plan;
+  } else {
+    RCLCPP_ERROR_STREAM(
+      node_->get_logger(),
+      get_plan_client_->get_service_name() << ": " <<
+        future_result.get()->error_info);
+    return {};
+  }
 }
 
 void

--- a/plansys2_executor/test/unit/btbuilder_tests.cpp
+++ b/plansys2_executor/test/unit/btbuilder_tests.cpp
@@ -61,12 +61,12 @@ public:
   explicit BTBuilderTest(rclcpp::Node::SharedPtr node)
   : BTBuilder(node) {}
 
-  std::string get_tree(const plansys2::Plan & current_plan)
+  std::string get_tree(const plansys2_msgs::msg::Plan & current_plan)
   {
     return BTBuilder::get_tree(current_plan);
   }
 
-  std::vector<plansys2::ActionStamped> get_plan_actions(const plansys2::Plan & plan)
+  std::vector<plansys2::ActionStamped> get_plan_actions(const plansys2_msgs::msg::Plan & plan)
   {
     return BTBuilder::get_plan_actions(plan);
   }
@@ -79,7 +79,7 @@ public:
     return BTBuilder::is_action_executable(action, predicates, functions);
   }
 
-  plansys2::Graph::Ptr get_graph(const plansys2::Plan & current_plan)
+  plansys2::Graph::Ptr get_graph(const plansys2_msgs::msg::Plan & current_plan)
   {
     return BTBuilder::get_graph(current_plan);
   }

--- a/plansys2_executor/test/unit/executor_test.cpp
+++ b/plansys2_executor/test/unit/executor_test.cpp
@@ -1155,7 +1155,7 @@ TEST(problem_expert, executor_client_execute_plan)
     rclcpp::Rate rate(10);
     auto start = test_node_1->now();
 
-    ASSERT_TRUE(executor_client->start_plan_execution());
+    ASSERT_TRUE(executor_client->start_plan_execution(plan.value()));
 
     while (rclcpp::ok() && executor_client->execute_and_check_plan()) {
       auto feedback = executor_client->getFeedBack();
@@ -1177,11 +1177,16 @@ TEST(problem_expert, executor_client_execute_plan)
 
   problem_client->setGoal(plansys2::Goal("(and(robot_at r2d2 body_car_zone))"));
 
+  problem = problem_client->getProblem();
+  plan = planner_client->getPlan(domain, problem);
+  ASSERT_FALSE(problem.empty());
+  ASSERT_TRUE(plan.has_value());
+
   {
     rclcpp::Rate rate(10);
     auto start = test_node_1->now();
 
-    ASSERT_TRUE(executor_client->start_plan_execution());
+    ASSERT_TRUE(executor_client->start_plan_execution(plan.value()));
 
     while (rclcpp::ok() && executor_client->execute_and_check_plan()) {
       auto feedback = executor_client->getFeedBack();
@@ -1375,7 +1380,7 @@ TEST(problem_expert, executor_client_ordered_sub_goals)
     rclcpp::Rate rate(10);
     auto start = test_node_1->now();
 
-    ASSERT_TRUE(executor_client->start_plan_execution());
+    ASSERT_TRUE(executor_client->start_plan_execution(plan.value()));
 
     while (rclcpp::ok() && executor_client->execute_and_check_plan()) {
       auto feedback = executor_client->getFeedBack();
@@ -1495,7 +1500,7 @@ TEST(problem_expert, executor_client_cancel_plan)
     rclcpp::Rate rate(10);
     auto start = test_node_1->now();
 
-    ASSERT_TRUE(executor_client->start_plan_execution());
+    ASSERT_TRUE(executor_client->start_plan_execution(plan.value()));
 
     while (rclcpp::ok() && executor_client->execute_and_check_plan()) {
       auto feedback = executor_client->getFeedBack();
@@ -1635,7 +1640,7 @@ TEST(problem_expert, action_timeout)
   {
     rclcpp::Rate rate(10);
 
-    ASSERT_TRUE(executor_client->start_plan_execution());
+    ASSERT_TRUE(executor_client->start_plan_execution(plan.value()));
 
     while (rclcpp::ok() && executor_client->execute_and_check_plan()) {
       auto feedback = executor_client->getFeedBack();

--- a/plansys2_msgs/CMakeLists.txt
+++ b/plansys2_msgs/CMakeLists.txt
@@ -17,6 +17,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/Knowledge.msg"
   "msg/Node.msg"
   "msg/Param.msg"
+  "msg/Plan.msg"
+  "msg/PlanItem.msg"
   "msg/Tree.msg"
   "srv/AddProblemGoal.srv"
   "srv/AffectNode.srv"

--- a/plansys2_msgs/action/ExecutePlan.action
+++ b/plansys2_msgs/action/ExecutePlan.action
@@ -1,4 +1,4 @@
-std_msgs/Empty request
+plansys2_msgs/Plan plan
 ---
 bool success
 plansys2_msgs/ActionExecutionInfo[] action_execution_status

--- a/plansys2_msgs/msg/Knowledge.msg
+++ b/plansys2_msgs/msg/Knowledge.msg
@@ -1,3 +1,4 @@
 string[] instances
 string[] predicates
+string[] functions
 string goal

--- a/plansys2_msgs/msg/Plan.msg
+++ b/plansys2_msgs/msg/Plan.msg
@@ -1,0 +1,1 @@
+plansys2_msgs/PlanItem[] items

--- a/plansys2_msgs/msg/PlanItem.msg
+++ b/plansys2_msgs/msg/PlanItem.msg
@@ -1,0 +1,3 @@
+float32 time
+string action
+float32 duration

--- a/plansys2_msgs/srv/GetPlan.srv
+++ b/plansys2_msgs/srv/GetPlan.srv
@@ -2,7 +2,5 @@ string domain
 string problem
 ---
 bool success
-float32[] times
-string[] actions
-float32[] durations
+plansys2_msgs/Plan plan
 string error_info

--- a/plansys2_planner/include/plansys2_planner/PlannerClient.hpp
+++ b/plansys2_planner/include/plansys2_planner/PlannerClient.hpp
@@ -33,7 +33,7 @@ class PlannerClient : public PlannerInterface
 public:
   explicit PlannerClient(rclcpp::Node::SharedPtr provided_node);
 
-  std::optional<Plan> getPlan(
+  std::optional<plansys2_msgs::msg::Plan> getPlan(
     const std::string & domain, const std::string & problem,
     const std::string & node_namespace = "");
 

--- a/plansys2_planner/include/plansys2_planner/PlannerInterface.hpp
+++ b/plansys2_planner/include/plansys2_planner/PlannerInterface.hpp
@@ -18,7 +18,7 @@
 #include <optional>
 #include <string>
 
-#include "plansys2_core/Types.hpp"
+#include "plansys2_msgs/msg/plan.hpp"
 
 namespace plansys2
 {
@@ -28,7 +28,7 @@ class PlannerInterface
 public:
   PlannerInterface() {}
 
-  virtual std::optional<Plan> getPlan(
+  virtual std::optional<plansys2_msgs::msg::Plan> getPlan(
     const std::string & domain, const std::string & problem,
     const std::string & node_namespace) = 0;
 };

--- a/plansys2_planner/src/plansys2_planner/PlannerClient.cpp
+++ b/plansys2_planner/src/plansys2_planner/PlannerClient.cpp
@@ -29,13 +29,11 @@ PlannerClient::PlannerClient(rclcpp::Node::SharedPtr provided_node)
   get_plan_client_ = node_->create_client<plansys2_msgs::srv::GetPlan>("planner/get_plan");
 }
 
-std::optional<Plan>
+std::optional<plansys2_msgs::msg::Plan>
 PlannerClient::getPlan(
   const std::string & domain, const std::string & problem,
   const std::string & node_namespace)
 {
-  Plan ret;
-
   while (!get_plan_client_->wait_for_service(std::chrono::seconds(30))) {
     if (!rclcpp::ok()) {
       return {};
@@ -59,14 +57,7 @@ PlannerClient::getPlan(
   }
 
   if (future_result.get()->success) {
-    for (size_t i = 0; i < future_result.get()->times.size(); i++) {
-      PlanItem item;
-      item.time = future_result.get()->times[i];
-      item.action = future_result.get()->actions[i];
-      item.duration = future_result.get()->durations[i];
-      ret.push_back(item);
-    }
-    return ret;
+    return future_result.get()->plan;
   } else {
     RCLCPP_ERROR_STREAM(
       node_->get_logger(),

--- a/plansys2_planner/src/plansys2_planner/PlannerNode.cpp
+++ b/plansys2_planner/src/plansys2_planner/PlannerNode.cpp
@@ -146,15 +146,10 @@ PlannerNode::get_plan_service_callback(
 {
   auto plan = solvers_.begin()->second->getPlan(
     request->domain, request->problem, get_namespace());
-  // auto plan = planner_->getPlan(request->domain, request->problem, get_namespace());
 
   if (plan) {
     response->success = true;
-    for (size_t i = 0; i < plan.value().size(); i++) {
-      response->times.push_back(plan.value()[i].time);
-      response->actions.push_back(plan.value()[i].action);
-      response->durations.push_back(plan.value()[i].duration);
-    }
+    response->plan = plan.value();
   } else {
     response->success = false;
     response->error_info = "Plan not found";

--- a/plansys2_planner/test/unit/planner_test.cpp
+++ b/plansys2_planner/test/unit/planner_test.cpp
@@ -32,7 +32,6 @@
 
 #include "pluginlib/class_loader.hpp"
 #include "pluginlib/class_list_macros.hpp"
-#include "plansys2_core/PlanSolverBase.hpp"
 
 #include "rclcpp/rclcpp.hpp"
 

--- a/plansys2_popf_plan_solver/include/plansys2_popf_plan_solver/popf_plan_solver.hpp
+++ b/plansys2_popf_plan_solver/include/plansys2_popf_plan_solver/popf_plan_solver.hpp
@@ -35,7 +35,7 @@ public:
 
   void configure(rclcpp_lifecycle::LifecycleNode::SharedPtr &, const std::string &);
 
-  std::optional<Plan> getPlan(
+  std::optional<plansys2_msgs::msg::Plan> getPlan(
     const std::string & domain, const std::string & problem,
     const std::string & node_namespace = "");
 

--- a/plansys2_popf_plan_solver/src/plansys2_popf_plan_solver/popf_plan_solver.cpp
+++ b/plansys2_popf_plan_solver/src/plansys2_popf_plan_solver/popf_plan_solver.cpp
@@ -22,6 +22,7 @@
 #include <cstdlib>
 #include <fstream>
 
+#include "plansys2_msgs/msg/plan_item.hpp"
 #include "plansys2_popf_plan_solver/popf_plan_solver.hpp"
 
 namespace plansys2
@@ -40,7 +41,7 @@ void POPFPlanSolver::configure(
   lc_node_->declare_parameter<std::string>(parameter_name_, "");
 }
 
-std::optional<Plan>
+std::optional<plansys2_msgs::msg::Plan>
 POPFPlanSolver::getPlan(
   const std::string & domain, const std::string & problem,
   const std::string & node_namespace)
@@ -55,7 +56,7 @@ POPFPlanSolver::getPlan(
     std::filesystem::create_directories(tp);
   }
 
-  Plan ret;
+  plansys2_msgs::msg::Plan ret;
   std::ofstream domain_out("/tmp/" + node_namespace + "/domain.pddl");
   domain_out << domain;
   domain_out.close();
@@ -81,7 +82,7 @@ POPFPlanSolver::getPlan(
           solution = true;
         }
       } else if (line.front() != ';') {
-        PlanItem item;
+        plansys2_msgs::msg::PlanItem item;
         size_t colon_pos = line.find(":");
         size_t colon_par = line.find(")");
         size_t colon_bra = line.find("[");
@@ -95,13 +96,13 @@ POPFPlanSolver::getPlan(
         item.action = action;
         item.duration = std::stof(duration);
 
-        ret.push_back(item);
+        ret.items.push_back(item);
       }
     }
     plan_file.close();
   }
 
-  if (ret.empty()) {
+  if (ret.items.empty()) {
     return {};
   } else {
     return ret;

--- a/plansys2_popf_plan_solver/test/unit/popf_test.cpp
+++ b/plansys2_popf_plan_solver/test/unit/popf_test.cpp
@@ -48,10 +48,10 @@ void test_plan_generation(const std::string & argument = "")
   auto plan = planner->getPlan(domain_str, problem_str, "generate_plan_good");
 
   ASSERT_TRUE(plan);
-  ASSERT_EQ(plan.value().size(), 3);
-  ASSERT_EQ(plan.value()[0].action, "(move leia kitchen bedroom)");
-  ASSERT_EQ(plan.value()[1].action, "(approach leia bedroom jack)");
-  ASSERT_EQ(plan.value()[2].action, "(talk leia jack jack m1)");
+  ASSERT_EQ(plan.value().items.size(), 3);
+  ASSERT_EQ(plan.value().items[0].action, "(move leia kitchen bedroom)");
+  ASSERT_EQ(plan.value().items[1].action, "(approach leia bedroom jack)");
+  ASSERT_EQ(plan.value().items[2].action, "(talk leia jack jack m1)");
 }
 
 TEST(popf_plan_solver, generate_plan_good)

--- a/plansys2_problem_expert/src/plansys2_problem_expert/ProblemExpertNode.cpp
+++ b/plansys2_problem_expert/src/plansys2_problem_expert/ProblemExpertNode.cpp
@@ -708,6 +708,10 @@ ProblemExpertNode::get_knowledge_as_msg() const
     ret_msgs->predicates.push_back(parser::pddl::toString(predicate));
   }
 
+  for (const auto & function : problem_expert_->getFunctions()) {
+    ret_msgs->functions.push_back(parser::pddl::toString(function));
+  }
+
   auto goal = problem_expert_->getGoal();
   ret_msgs->goal = parser::pddl::toString(goal);
 

--- a/plansys2_terminal/src/plansys2_terminal/Terminal.cpp
+++ b/plansys2_terminal/src/plansys2_terminal/Terminal.cpp
@@ -419,9 +419,9 @@ Terminal::process_get(std::vector<std::string> & command, std::ostringstream & o
 
       if (plan) {
         os << "plan: " << std::endl;
-        for (const auto & action : plan.value()) {
-          os << action.time << "\t" << action.action << "\t" <<
-            action.duration << std::endl;
+        for (const auto & plan_item : plan.value().items) {
+          os << plan_item.time << "\t" << plan_item.action << "\t" <<
+            plan_item.duration << std::endl;
         }
       } else {
         os << "No se ha encontrado plan" << std::endl;
@@ -472,16 +472,12 @@ Terminal::process_set_predicate(std::vector<std::string> & command, std::ostring
       pop_front(command);
     }
 
-    if (!predicate.parameters.empty()) {
-      if (predicate.parameters.back().name.back() != ')') {
-        os << "\tUsage: \n\t\tset predicate (predicate)" << std::endl;
-        return;
-      }
-
-      predicate.parameters.back().name.pop_back();  // Remove last (
-    } else {
-      predicate.name.pop_back();  // Remove last (
+    if (predicate.parameters.back().name.back() != ')') {
+      os << "\tUsage: \n\t\tset predicate (predicate)" << std::endl;
+      return;
     }
+
+    predicate.parameters.back().name.pop_back();  // Remove last (
 
     if (!problem_client_->addPredicate(predicate)) {
       os << "Could not add the predicate [" << parser::pddl::toString(predicate) << "]" <<
@@ -685,7 +681,14 @@ Terminal::execute_plan()
 {
   rclcpp::Rate loop_rate(5);
 
-  if (!executor_client_->start_plan_execution()) {
+  auto plan = planner_client_->getPlan(domain_client_->getDomain(), problem_client_->getProblem());
+
+  if (!plan.has_value()) {
+    std::cout << "Plan could not be computed " << std::endl;
+    return;
+  }
+
+  if (!executor_client_->start_plan_execution(plan.value())) {
     std::cout << "Execution could not start " << std::endl;
     return;
   }

--- a/plansys2_tests/test_1/test_1.cpp
+++ b/plansys2_tests/test_1/test_1.cpp
@@ -119,7 +119,15 @@ TEST(test_1, test_1)
 
   problem_client->setGoal(plansys2::Goal("(and(robot_at leia bathroom))"));
 
-  ASSERT_TRUE(executor_client->start_plan_execution());
+  auto domain = domain_client->getDomain();
+  auto problem = problem_client->getProblem();
+  auto plan = planner_client->getPlan(domain, problem);
+
+  ASSERT_FALSE(domain.empty());
+  ASSERT_FALSE(problem.empty());
+  ASSERT_TRUE(plan.has_value());
+
+  ASSERT_TRUE(executor_client->start_plan_execution(plan.value()));
 
   rclcpp::Rate rate(5);
   while (executor_client->execute_and_check_plan()) {

--- a/plansys2_tests/test_2/test_2.cpp
+++ b/plansys2_tests/test_2/test_2.cpp
@@ -119,7 +119,15 @@ TEST(test_2, test_2)
 
   problem_client->setGoal(plansys2::Goal("(and(robot_at leia zone_1_2))"));
 
-  ASSERT_TRUE(executor_client->start_plan_execution());
+  auto domain = domain_client->getDomain();
+  auto problem = problem_client->getProblem();
+  auto plan = planner_client->getPlan(domain, problem);
+
+  ASSERT_FALSE(domain.empty());
+  ASSERT_FALSE(problem.empty());
+  ASSERT_TRUE(plan.has_value());
+
+  ASSERT_TRUE(executor_client->start_plan_execution(plan.value()));
 
   rclcpp::Rate rate(5);
   while (executor_client->execute_and_check_plan()) {

--- a/plansys2_tests/test_3/test_3.cpp
+++ b/plansys2_tests/test_3/test_3.cpp
@@ -169,7 +169,15 @@ TEST(test_3, test_3)
     plansys2::Goal(
       "(and(car_assembled car1) (car_assembled car2) (car_assembled car3))"));
 
-  ASSERT_TRUE(executor_client->start_plan_execution());
+  auto domain = domain_client->getDomain();
+  auto problem = problem_client->getProblem();
+  auto plan = planner_client->getPlan(domain, problem);
+
+  ASSERT_FALSE(domain.empty());
+  ASSERT_FALSE(problem.empty());
+  ASSERT_TRUE(plan.has_value());
+
+  ASSERT_TRUE(executor_client->start_plan_execution(plan.value()));
 
   rclcpp::Rate rate(5);
   while (executor_client->execute_and_check_plan()) {


### PR DESCRIPTION
There are 3 main changes in this PR.

1.  A new Plan message was created. This message contains the same information that was previously defined in plansys2_core/Types.hpp. To remove redundancy in the system, all instances of the Types.hpp data structure have been replaced with the new message.
2. A getPlan function was added to the executor client and a corresponding service was added to the executor node. This function/service returns the currently executing plan.
3. The plan to execute is now passed into the execute function of the executor node via the goal service request of the ExecutePlan action. Previously an empty goal request was used and the plan was computed inside the executor.

Passing the plan into the executor allows for greater separation between the plan creation and the plan execution. In particular, it allows for greater control over the plan creation, including modifying the problem knowledge prior to plan generation and verifying the resulting plan prior to execution.

Note that the new approach requires the client-side software to compute the plan and pass the plan to the executor. Computing the plan is accomplished via the planner client, e.g.,

    auto plan = planner_client_->getPlan(domain, problem);

Passing the plan to the executor is accomplished via the executor client, e.g.,

    executor_client_->start_plan_execution(plan.value());