### PR TITLE
Add ability to read in pddl problem files to plansys2.

### DIFF
--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpert.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpert.hpp
@@ -120,6 +120,13 @@ public:
    */
   std::string getDomain();
 
+  /// Determine if a particular domain exists.
+  /**
+   * \param[in] domain The name of the domain.
+   * \return true if the domain exists.
+   */
+  bool existDomain(const std::string & domain_name);
+
 private:
   std::shared_ptr<parser::pddl::Domain> domain_;
   DomainReader domains_;

--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainReader.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainReader.hpp
@@ -23,6 +23,7 @@ namespace plansys2
 
 struct Domain
 {
+  std::string name;
   std::string requirements;
   std::string types;
   std::string predicates;
@@ -37,10 +38,12 @@ public:
 
   void add_domain(const std::string & domain);
   std::string get_joint_domain() const;
+  std::vector<Domain> get_domains() {return domains_;}
 
 protected:
   int get_end_block(const std::string & domain, std::size_t init_pos);
 
+  std::string get_name(std::string & domain);
   std::string get_requirements(std::string & domain);
   std::string get_types(const std::string & domain);
   std::string get_predicates(const std::string & domain);

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpert.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpert.cpp
@@ -311,4 +311,15 @@ DomainExpert::getDomain()
   return domains_.get_joint_domain();
 }
 
+bool
+DomainExpert::existDomain(const std::string & domain_name)
+{
+  for (auto domain : domains_.get_domains()) {
+    if (domain_name == domain.name) {
+      return true;
+    }
+  }
+  return false;
+}
+
 }  // namespace plansys2

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainReader.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainReader.cpp
@@ -48,6 +48,7 @@ DomainReader::add_domain(const std::string & domain)
 
   lc_domain = remove_comments(lc_domain);
 
+  new_domain.name = get_name(lc_domain);
   new_domain.requirements = get_requirements(lc_domain);
   new_domain.types = get_types(lc_domain);
   new_domain.predicates = get_predicates(lc_domain);
@@ -137,6 +138,31 @@ DomainReader::get_end_block(const std::string & domain, std::size_t init_pos)
     return end_pos;
   } else {
     return -1;
+  }
+}
+
+std::string
+DomainReader::get_name(std::string & domain)
+{
+  const std::string pattern("domain");
+
+  std::size_t init_pos = domain.find(pattern);
+  if (init_pos == std::string::npos) {
+    return "";
+  }
+  init_pos += pattern.length();
+
+  auto end_pos = get_end_block(domain, init_pos);
+
+  if (end_pos >= 0) {
+    auto ret = substr_without_empty_lines(domain, init_pos, end_pos);
+
+    // remove spaces
+    ret.erase(std::remove(ret.begin(), ret.end(), ' '), ret.end());
+
+    return ret;
+  } else {
+    return "";
   }
 }
 

--- a/plansys2_domain_expert/test/unit/domain_expert_test.cpp
+++ b/plansys2_domain_expert/test/unit/domain_expert_test.cpp
@@ -26,7 +26,7 @@
 
 #include "plansys2_msgs/msg/node.hpp"
 
-TEST(domain_expert, functions)
+TEST(domain_expert, get_reduced_string)
 {
   std::string my_string("(and)");
   ASSERT_EQ(parser::pddl::getReducedString(my_string), "(and)");
@@ -46,6 +46,26 @@ TEST(domain_expert, functions)
   ASSERT_EQ(parser::pddl::getReducedString(my_string), "(and)");
   my_string = "( ( and\n\t ) )";
   ASSERT_EQ(parser::pddl::getReducedString(my_string), "((and))");
+}
+
+TEST(domain_expert, exist_domain)
+{
+  std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_domain_expert");
+  std::ifstream domain_ifs(pkgpath + "/pddl/domain_charging.pddl");
+  std::string domain_str((
+      std::istreambuf_iterator<char>(domain_ifs)),
+    std::istreambuf_iterator<char>());
+
+  plansys2::DomainExpert domain_expert(domain_str);
+  ASSERT_TRUE(domain_expert.existDomain("charging"));
+
+  std::ifstream domain_simple_ifs(pkgpath + "/pddl/domain_simple.pddl");
+  std::string domain_simple_str((
+      std::istreambuf_iterator<char>(domain_simple_ifs)),
+    std::istreambuf_iterator<char>());
+
+  domain_expert.extendDomain(domain_simple_str);
+  ASSERT_TRUE(domain_expert.existDomain("plansys2"));
 }
 
 TEST(domain_expert, get_domain)

--- a/plansys2_domain_expert/test/unit/domain_reader_test.cpp
+++ b/plansys2_domain_expert/test/unit/domain_reader_test.cpp
@@ -30,6 +30,11 @@ public:
     return get_end_block(domain, init_pos);
   }
 
+  std::string get_name_test(std::string & domain)
+  {
+    return get_name(domain);
+  }
+
   std::string get_requirements_test(std::string & domain)
   {
     return get_requirements(domain);
@@ -92,6 +97,43 @@ TEST(domain_reader, get_block)
   ASSERT_EQ(6, dr.get_end_block_test(block8, 0));
   ASSERT_EQ(-1, dr.get_end_block_test(block9, 0));
   ASSERT_EQ(-1, dr.get_end_block_test(block10, 0));
+}
+
+TEST(domain_reader, name)
+{
+  DomainReaderTest dr;
+
+  std::string name1_str = "(define (domain simple)";
+  std::string name1_estr = "simple";
+
+  std::string name2_str = "(\ndefine (\ndomain simple\n)";
+  std::string name2_estr = "simple";
+
+  std::string name3_str = "(define (domain simple\n) (\n))";
+  std::string name3_estr = "simple";
+
+  std::string name4_str = "(define (domain simple";
+  std::string name4_estr = "";
+
+  std::string name5_str = "(define (domain ";
+  std::string name5_estr = "";
+
+  std::string name6_str = "";
+  std::string name6_estr = "";
+
+  auto res1 = dr.get_name_test(name1_str);
+  auto res2 = dr.get_name_test(name2_str);
+  auto res3 = dr.get_name_test(name3_str);
+  auto res4 = dr.get_name_test(name4_str);
+  auto res5 = dr.get_name_test(name5_str);
+  auto res6 = dr.get_name_test(name6_str);
+
+  ASSERT_EQ(res1, name1_estr);
+  ASSERT_EQ(res2, name2_estr);
+  ASSERT_EQ(res3, name3_estr);
+  ASSERT_EQ(res4, name4_estr);
+  ASSERT_EQ(res5, name5_estr);
+  ASSERT_EQ(res6, name6_estr);
 }
 
 TEST(domain_reader, requirements)

--- a/plansys2_msgs/CMakeLists.txt
+++ b/plansys2_msgs/CMakeLists.txt
@@ -20,6 +20,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/Plan.msg"
   "msg/PlanItem.msg"
   "msg/Tree.msg"
+  "srv/AddProblem.srv"
   "srv/AddProblemGoal.srv"
   "srv/AffectNode.srv"
   "srv/AffectParam.srv"

--- a/plansys2_msgs/srv/AddProblem.srv
+++ b/plansys2_msgs/srv/AddProblem.srv
@@ -1,0 +1,4 @@
+string problem
+---
+bool success
+string error_info

--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/GroundFunc.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/GroundFunc.h
@@ -25,6 +25,10 @@ public:
 
 	plansys2_msgs::msg::Node::SharedPtr getTree( plansys2_msgs::msg::Tree & tree, const Domain & d, const std::vector<std::string> & replace = {} ) const override;
 
+	void print( std::ostream & stream ) const {
+		stream << name << params << value << "\n";
+	}
+
 	void parse( Stringreader & f, TokenStruct< std::string > & ts, Domain & d );
 
 };

--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/Instance.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/Instance.h
@@ -49,7 +49,24 @@ public:
 		}
 	}
 
-	
+	std::string getDomainName( const std::string &s) {
+		std::string domain_name = "";
+
+		Stringreader f( s );
+		f.parseName( "problem" );
+
+		for ( ; f.getChar() != ')'; f.next() ) {
+			f.assert_token( "(" );
+			f.assert_token( ":" );
+			std::string t = f.getToken();
+			if ( t == "domain" ) {
+				f.next();
+				domain_name = f.getToken();
+				break;
+			}
+		}
+		return domain_name;
+	}
 
 	void parseDomain( Stringreader & f ) {
 		f.next();

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Ground.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Ground.cpp
@@ -30,6 +30,8 @@ plansys2_msgs::msg::Node::SharedPtr Ground::getTree( plansys2_msgs::msg::Tree & 
         plansys2_msgs::msg::Param param;
         if (i < replace.size()) {
           param.name = replace[params[i]];
+        } else if (d.types[lifted->params[i]]->objects.size() > params[i]) {
+          param.name = d.types[lifted->params[i]]->object( params[i] ).first;
         } else {
           param.name = "?" + std::to_string(params[i]);
         }

--- a/plansys2_problem_expert/include/plansys2_problem_expert/ProblemExpert.hpp
+++ b/plansys2_problem_expert/include/plansys2_problem_expert/ProblemExpert.hpp
@@ -62,6 +62,7 @@ public:
   bool clearKnowledge();
 
   std::string getProblem();
+  bool addProblem(const std::string & problem_str);
 
   bool existInstance(const std::string & name);
   bool isValidType(const std::string & type);

--- a/plansys2_problem_expert/include/plansys2_problem_expert/ProblemExpertClient.hpp
+++ b/plansys2_problem_expert/include/plansys2_problem_expert/ProblemExpertClient.hpp
@@ -25,6 +25,7 @@
 #include "plansys2_msgs/msg/node.hpp"
 #include "plansys2_msgs/msg/param.hpp"
 #include "plansys2_msgs/msg/tree.hpp"
+#include "plansys2_msgs/srv/add_problem.hpp"
 #include "plansys2_msgs/srv/add_problem_goal.hpp"
 #include "plansys2_msgs/srv/affect_node.hpp"
 #include "plansys2_msgs/srv/affect_param.hpp"
@@ -75,8 +76,11 @@ public:
   bool clearKnowledge();
 
   std::string getProblem();
+  bool addProblem(const std::string & problem_str);
 
 private:
+  rclcpp::Client<plansys2_msgs::srv::AddProblem>::SharedPtr
+    add_problem_client_;
   rclcpp::Client<plansys2_msgs::srv::AddProblemGoal>::SharedPtr
     add_problem_goal_client_;
   rclcpp::Client<plansys2_msgs::srv::AffectParam>::SharedPtr

--- a/plansys2_problem_expert/include/plansys2_problem_expert/ProblemExpertInterface.hpp
+++ b/plansys2_problem_expert/include/plansys2_problem_expert/ProblemExpertInterface.hpp
@@ -58,6 +58,7 @@ public:
   virtual bool clearKnowledge() = 0;
 
   virtual std::string getProblem() = 0;
+  virtual bool addProblem(const std::string & problem_str) = 0;
 };
 
 }  // namespace plansys2

--- a/plansys2_problem_expert/include/plansys2_problem_expert/ProblemExpertNode.hpp
+++ b/plansys2_problem_expert/include/plansys2_problem_expert/ProblemExpertNode.hpp
@@ -26,6 +26,7 @@
 #include "plansys2_msgs/msg/knowledge.hpp"
 #include "plansys2_msgs/srv/affect_node.hpp"
 #include "plansys2_msgs/srv/affect_param.hpp"
+#include "plansys2_msgs/srv/add_problem.hpp"
 #include "plansys2_msgs/srv/add_problem_goal.hpp"
 #include "plansys2_msgs/srv/exist_node.hpp"
 #include "plansys2_msgs/srv/get_problem.hpp"
@@ -60,6 +61,11 @@ public:
   CallbackReturnT on_error(const rclcpp_lifecycle::State & state);
 
   plansys2_msgs::msg::Knowledge::SharedPtr get_knowledge_as_msg() const;
+
+  void add_problem_service_callback(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<plansys2_msgs::srv::AddProblem::Request> request,
+    const std::shared_ptr<plansys2_msgs::srv::AddProblem::Response> response);
 
   void add_problem_goal_service_callback(
     const std::shared_ptr<rmw_request_id_t> request_header,
@@ -169,6 +175,8 @@ public:
 private:
   std::shared_ptr<ProblemExpert> problem_expert_;
 
+  rclcpp::Service<plansys2_msgs::srv::AddProblem>::SharedPtr
+    add_problem_service_;
   rclcpp::Service<plansys2_msgs::srv::AddProblemGoal>::SharedPtr
     add_problem_goal_service_;
   rclcpp::Service<plansys2_msgs::srv::AffectParam>::SharedPtr

--- a/plansys2_problem_expert/src/plansys2_problem_expert/ProblemExpert.cpp
+++ b/plansys2_problem_expert/src/plansys2_problem_expert/ProblemExpert.cpp
@@ -16,6 +16,7 @@
 
 #include <optional>
 #include <algorithm>
+#include <stdexcept>
 #include <string>
 #include <vector>
 #include <memory>
@@ -622,7 +623,13 @@ ProblemExpert::addProblem(const std::string & problem_str)
   }
 
   domain.name = domain_name;
-  problem.parse(lc_problem);
+  try {
+    problem.parse(lc_problem);
+  } catch (std::runtime_error ex) {
+    // all errors thrown by the Stringreader object extend std::runtime_error
+    std::cerr << ex.what() << std::endl;
+    return false;
+  }
 
   std::cout << "Parsed problem: " << problem << std::endl;
 

--- a/plansys2_problem_expert/test/pddl/problem_empty_domain.pddl
+++ b/plansys2_problem_expert/test/pddl/problem_empty_domain.pddl
@@ -1,5 +1,5 @@
 (define (problem simple_1)
-  (:domain simple)
+  (:domain )
   (:objects
     leia - robot
     Jack - person
@@ -9,7 +9,6 @@
   (:init
     (robot_at leia kitchen)
     (person_at Jack bedroom)
-    (= (room_distance kitchen bedroom) 10)
 
 
   )

--- a/plansys2_problem_expert/test/pddl/problem_unexpected_syntax.pddl
+++ b/plansys2_problem_expert/test/pddl/problem_unexpected_syntax.pddl
@@ -9,6 +9,8 @@
   (:init
     (robot_at leia kitchen)
     (person_at Jack bedroom)
+    (is_teleporter_destination kitchen bedroom)
+    (= (room_distance leia kitchen bedroom) 10)
     (= (room_distance kitchen bedroom) 10)
 
 

--- a/plansys2_problem_expert/test/pddl/problem_unexpected_syntax.pddl
+++ b/plansys2_problem_expert/test/pddl/problem_unexpected_syntax.pddl
@@ -9,9 +9,13 @@
   (:init
     (robot_at leia kitchen)
     (person_at Jack bedroom)
-    (is_teleporter_destination kitchen bedroom)
-    (= (room_distance leia kitchen bedroom) 10)
     (= (room_distance kitchen bedroom) 10)
+
+    ;; problem syntax below
+    ;; too many rooms specified
+    (is_teleporter_destination kitchen bedroom)
+    ;; robot erroneously specified
+    (= (room_distance leia kitchen) 10)
 
 
   )

--- a/plansys2_terminal/include/plansys2_terminal/Terminal.hpp
+++ b/plansys2_terminal/include/plansys2_terminal/Terminal.hpp
@@ -46,6 +46,8 @@ public:
 protected:
   virtual void init();
 
+  virtual void add_problem();
+
   virtual void clean_command(std::string & command);
 
   virtual void process_get_model_predicate(
@@ -88,6 +90,8 @@ private:
   std::shared_ptr<plansys2::ProblemExpertClient> problem_client_;
   std::shared_ptr<plansys2::PlannerClient> planner_client_;
   std::shared_ptr<plansys2::ExecutorClient> executor_client_;
+
+  std::string problem_file_name_;
 };
 
 }  // namespace plansys2_terminal

--- a/plansys2_terminal/src/plansys2_terminal/Terminal.cpp
+++ b/plansys2_terminal/src/plansys2_terminal/Terminal.cpp
@@ -152,6 +152,7 @@ char ** completer(const char * text, int start, int end)
 
   return rl_completion_matches(text, completion_generator);
 }
+// LCOV_EXCL_STOP
 
 
 Terminal::Terminal()
@@ -191,6 +192,7 @@ void Terminal::add_problem()
   }
 }
 
+// LCOV_EXCL_START
 void
 Terminal::run_console()
 {

--- a/plansys2_terminal/test/pddl/problem_charging.pddl
+++ b/plansys2_terminal/test/pddl/problem_charging.pddl
@@ -1,0 +1,29 @@
+(define (problem simple-problem)
+  (:domain simple)
+
+  ;; Instantiate the objects.
+  (:objects 
+    r2d2 - robot
+    rm0 rm1 rm2 - room
+  )
+
+  (:init
+    ;; Define the initial state predicates.
+    (robot_at r2d2 rm0)
+    (charging_point_at rm0)
+
+    (connected rm0 rm1)
+    (connected rm1 rm0)
+    (connected rm1 rm2)
+    (connected rm2 rm1)
+    (battery_low r2d2)
+  )
+
+  (:goal (and
+    (robot_at r2d2 rm2)
+  ))
+    
+  (:metric 
+    minimize (total-time)
+  )
+)

--- a/plansys2_terminal/test/pddl/problem_empty_domain.pddl
+++ b/plansys2_terminal/test/pddl/problem_empty_domain.pddl
@@ -1,0 +1,21 @@
+(define (problem simple_1)
+  (:domain )
+  (:objects
+    leia - robot
+    Jack - person
+    kitchen bedroom - room
+    m1 - message
+  )
+  (:init
+    (robot_at leia kitchen)
+    (person_at Jack bedroom)
+
+
+  )
+
+  ;; The goal is to have both packages delivered to their destinations:
+  (:goal (and
+    (robot_talk leia m1 Jack) 
+    )
+  )
+  )

--- a/plansys2_terminal/test/terminal_test.cpp
+++ b/plansys2_terminal/test/terminal_test.cpp
@@ -535,6 +535,217 @@ TEST_F(TerminalTestCase, load_popf_plugin)
   t.join();
 }
 
+TEST_F(TerminalTestCase, add_problem)
+{
+  auto test_node = rclcpp::Node::make_shared("terminal_node_test");
+
+  auto domain_node = std::make_shared<plansys2::DomainExpertNode>();
+  auto problem_node = std::make_shared<plansys2::ProblemExpertNode>();
+  auto planner_node = std::make_shared<plansys2::PlannerNode>();
+  auto executor_node = std::make_shared<plansys2::ExecutorNode>();
+
+  auto problem_client = std::make_shared<plansys2::ProblemExpertClient>(test_node);
+
+  std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_terminal");
+
+  domain_node->set_parameter({"model_file", pkgpath + "/pddl/simple_example.pddl"});
+  problem_node->set_parameter({"model_file", pkgpath + "/pddl/simple_example.pddl"});
+
+  rclcpp::executors::MultiThreadedExecutor exe(rclcpp::executor::ExecutorArgs(), 16, true);
+  ASSERT_GT(exe.get_number_of_threads(), 15u);
+
+  exe.add_node(domain_node->get_node_base_interface());
+  exe.add_node(problem_node->get_node_base_interface());
+  exe.add_node(planner_node->get_node_base_interface());
+  exe.add_node(executor_node->get_node_base_interface());
+
+  std::thread t([&]() {
+      exe.spin();
+    });
+
+  domain_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  problem_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  planner_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  executor_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = test_node->now();
+    while ((test_node->now() - start).seconds() < 0.5) {
+      rate.sleep();
+    }
+  }
+
+  domain_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  rclcpp_lifecycle::State state = problem_node->trigger_transition(
+    lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+  std::string stateLabel = state.label();
+
+  planner_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+  executor_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = test_node->now();
+    while ((test_node->now() - start).seconds() < 0.5) {
+      rate.sleep();
+    }
+  }
+
+  auto terminal_node = std::make_shared<TerminalTest>();
+  terminal_node->set_parameter({"problem_file", pkgpath + "/pddl/problem_charging.pddl"});
+  terminal_node->init();
+
+  ASSERT_EQ(problem_client->getInstances().size(), 4);
+  ASSERT_EQ(problem_client->getPredicates().size(), 7);
+  ASSERT_EQ(problem_client->getFunctions().size(), 0);
+
+  {
+    auto ins_1 = problem_client->getInstance("r2d2");
+    ASSERT_TRUE(ins_1.has_value());
+    ASSERT_EQ(ins_1.value().name, "r2d2");
+    ASSERT_EQ(ins_1.value().type, "robot");
+  }
+
+  {
+    std::vector<std::string> rooms = {"rm0", "rm1", "rm2"};
+    for (auto room_name : rooms) {
+      auto ins_2 = problem_client->getInstance(room_name);
+      ASSERT_TRUE(ins_2.has_value());
+      ASSERT_EQ(ins_2.value().name, room_name);
+      ASSERT_EQ(ins_2.value().type, "room");
+    }
+  }
+
+  ASSERT_EQ(parser::pddl::toString(problem_client->getGoal()), "(and (robot_at r2d2 rm2))");
+
+  domain_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+  problem_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+  planner_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+  executor_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = test_node->now();
+    while ((test_node->now() - start).seconds() < 0.5) {
+      rate.sleep();
+    }
+  }
+
+  domain_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_INACTIVE_SHUTDOWN);
+  problem_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_INACTIVE_SHUTDOWN);
+  planner_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_INACTIVE_SHUTDOWN);
+  executor_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_INACTIVE_SHUTDOWN);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = test_node->now();
+    while ((test_node->now() - start).seconds() < 0.5) {
+      rate.sleep();
+    }
+  }
+
+  exe.cancel();
+  t.join();
+}
+
+TEST_F(TerminalTestCase, add_problem_empty_domain)
+{
+  auto test_node = rclcpp::Node::make_shared("terminal_node_test");
+
+  auto domain_node = std::make_shared<plansys2::DomainExpertNode>();
+  auto problem_node = std::make_shared<plansys2::ProblemExpertNode>();
+  auto planner_node = std::make_shared<plansys2::PlannerNode>();
+  auto executor_node = std::make_shared<plansys2::ExecutorNode>();
+
+  auto problem_client = std::make_shared<plansys2::ProblemExpertClient>(test_node);
+
+  std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_terminal");
+
+  domain_node->set_parameter({"model_file", pkgpath + "/pddl/simple_example.pddl"});
+  problem_node->set_parameter({"model_file", pkgpath + "/pddl/simple_example.pddl"});
+
+  rclcpp::executors::MultiThreadedExecutor exe(rclcpp::executor::ExecutorArgs(), 16, true);
+  ASSERT_GT(exe.get_number_of_threads(), 15u);
+
+  exe.add_node(domain_node->get_node_base_interface());
+  exe.add_node(problem_node->get_node_base_interface());
+  exe.add_node(planner_node->get_node_base_interface());
+  exe.add_node(executor_node->get_node_base_interface());
+
+  std::thread t([&]() {
+      exe.spin();
+    });
+
+  domain_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  problem_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  planner_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  executor_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = test_node->now();
+    while ((test_node->now() - start).seconds() < 0.5) {
+      rate.sleep();
+    }
+  }
+
+  domain_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  rclcpp_lifecycle::State state = problem_node->trigger_transition(
+    lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+  std::string stateLabel = state.label();
+
+  planner_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+  executor_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = test_node->now();
+    while ((test_node->now() - start).seconds() < 0.5) {
+      rate.sleep();
+    }
+  }
+
+  auto terminal_node = std::make_shared<TerminalTest>();
+  terminal_node->set_parameter({"problem_file", pkgpath + "/pddl/problem_empty_domain.pddl"});
+  terminal_node->init();
+
+  ASSERT_EQ(problem_client->getInstances().size(), 0);
+  ASSERT_EQ(problem_client->getPredicates().size(), 0);
+  ASSERT_EQ(problem_client->getFunctions().size(), 0);
+
+  domain_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+  problem_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+  planner_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+  executor_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = test_node->now();
+    while ((test_node->now() - start).seconds() < 0.5) {
+      rate.sleep();
+    }
+  }
+
+  domain_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_INACTIVE_SHUTDOWN);
+  problem_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_INACTIVE_SHUTDOWN);
+  planner_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_INACTIVE_SHUTDOWN);
+  executor_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_INACTIVE_SHUTDOWN);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = test_node->now();
+    while ((test_node->now() - start).seconds() < 0.5) {
+      rate.sleep();
+    }
+  }
+
+  exe.cancel();
+  t.join();
+}
+
 TEST_F(TerminalTestCase, check_actors)
 {
   auto test_node = rclcpp::Node::make_shared("terminal_node_test");


### PR DESCRIPTION
Add a new AddProblem service to the plansys2_problem_expert.
Adding problem_file node parameter to plansys2_problem_expert to load a single problem file at launch.

Signed-off-by: Alexander Xydes <alexander.xydes@navy.mil>