### PR TITLE
PDDL Constants:  Extract "(:constants )" string from PDDL domain_str. 

### DIFF
--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainReader.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainReader.hpp
@@ -25,6 +25,7 @@ struct Domain
 {
   std::string requirements;
   std::string types;
+  std::string constants;
   std::string predicates;
   std::string functions;
   std::vector<std::string> actions;
@@ -43,6 +44,7 @@ protected:
 
   std::string get_requirements(std::string & domain);
   std::string get_types(const std::string & domain);
+  std::string get_constants(const std::string & domain);
   std::string get_predicates(const std::string & domain);
   std::string get_functions(const std::string & domain);
   std::vector<std::string> get_actions(const std::string & domain);

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainReader.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainReader.cpp
@@ -50,6 +50,7 @@ DomainReader::add_domain(const std::string & domain)
 
   new_domain.requirements = get_requirements(lc_domain);
   new_domain.types = get_types(lc_domain);
+  new_domain.constants = get_constants(lc_domain);
   new_domain.predicates = get_predicates(lc_domain);
   new_domain.functions = get_functions(lc_domain);
   new_domain.actions = get_actions(lc_domain);
@@ -78,6 +79,14 @@ DomainReader::get_joint_domain() const
   for (auto & domain : domains_) {
     if (!domain.types.empty()) {
       ret += domain.types + "\n";
+    }
+  }
+  ret += ")\n\n";
+
+  ret += "(:constants\n";
+  for (auto & domain : domains_) {
+    if (!domain.constants.empty()) {
+      ret += domain.constants + "\n";
     }
   }
   ret += ")\n\n";
@@ -184,6 +193,29 @@ DomainReader::get_types(const std::string & domain)
     return "";
   }
 }
+
+
+std::string
+DomainReader::get_constants(const std::string & domain)
+{
+  const std::string pattern(":constants");
+
+  std::size_t init_pos = domain.find(pattern);
+  if (init_pos == std::string::npos) {
+    return "";
+  }
+  init_pos += pattern.length();
+
+  auto end_pos = get_end_block(domain, init_pos);
+
+  if (end_pos >= 0) {
+    std::string ret = substr_without_empty_lines(domain, init_pos, end_pos);
+    return ret;
+  } else {
+    return "";
+  }
+}
+
 
 std::string
 DomainReader::get_predicates(const std::string & domain)


### PR DESCRIPTION
This PR fixes  #135.  Which caused issues during parsing and checking of a pddl domains files which uses a constant defined in `(: constants )`.

