### PR TITLE
Pddl domain (:constants ) handling and planning

### DIFF
--- a/plansys2_domain_expert/README.md
+++ b/plansys2_domain_expert/README.md
@@ -20,4 +20,4 @@ The Domain Expert does not change while active, accessing its functionality thro
 - `/domain_expert/get_domain_predicate_details` [[`plansys2_msgs::srv::GetNodeDetails`](../plansys2_msgs/srv/GetNode.srv)]
 - `/domain_expert/get_domain_predicates` [[`plansys2_msgs::srv::GetStates`](../plansys2_msgs/srv/GetStates.srv)]
 - `/domain_expert/get_domain_types` [[`plansys2_msgs::srv::GetDomainTypes`](../plansys2_msgs/srv/GetDomainTypes.srv)]
-- `/domain_expert/get_domain_constants` [[`plansys2_msgs::srv::GetDomainConstatns`](../plansys2_msgs/srv/GetDomainConstants.srv)]
+- `/domain_expert/get_domain_constants` [[`plansys2_msgs::srv::GetDomainConstants`](../plansys2_msgs/srv/GetDomainConstants.srv)]

--- a/plansys2_domain_expert/README.md
+++ b/plansys2_domain_expert/README.md
@@ -20,3 +20,4 @@ The Domain Expert does not change while active, accessing its functionality thro
 - `/domain_expert/get_domain_predicate_details` [[`plansys2_msgs::srv::GetNodeDetails`](../plansys2_msgs/srv/GetNode.srv)]
 - `/domain_expert/get_domain_predicates` [[`plansys2_msgs::srv::GetStates`](../plansys2_msgs/srv/GetStates.srv)]
 - `/domain_expert/get_domain_types` [[`plansys2_msgs::srv::GetDomainTypes`](../plansys2_msgs/srv/GetDomainTypes.srv)]
+- `/domain_expert/get_domain_constants` [[`plansys2_msgs::srv::GetDomainConstatns`](../plansys2_msgs/srv/GetDomainConstants.srv)]

--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpert.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpert.hpp
@@ -60,6 +60,13 @@ public:
    */
   std::vector<std::string> getTypes();
 
+  /// Get the details of a constants existing for a type.
+  /**
+   * \param[in] predicate The name of the type.
+   * \return A list of constants names for the passed type
+   */
+  std::vector<std::string> getConstants(const std::string & type);
+
   /// Get the predicates existing in the domain.
   /**
    * \return The vector containing the name of the predicates.

--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertClient.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertClient.hpp
@@ -30,6 +30,7 @@
 #include "plansys2_msgs/srv/get_domain.hpp"
 #include "plansys2_msgs/srv/get_domain_name.hpp"
 #include "plansys2_msgs/srv/get_domain_types.hpp"
+#include "plansys2_msgs/srv/get_domain_constants.hpp"
 #include "plansys2_msgs/srv/get_domain_actions.hpp"
 #include "plansys2_msgs/srv/get_domain_action_details.hpp"
 #include "plansys2_msgs/srv/get_domain_durative_action_details.hpp"
@@ -64,6 +65,13 @@ public:
    * \return The vector containing the name of the predicates.
    */
   std::vector<std::string> getTypes();
+
+  /// Get the details of a constants existing for a type.
+  /**
+   * \param[in] predicate The name of the type.
+   * \return A list of constants names for the passed type
+   */
+  std::vector<std::string> getConstants(const std::string & type);
 
   /// Get the predicates existing in the domain.
   /**
@@ -137,6 +145,7 @@ private:
   rclcpp::Client<plansys2_msgs::srv::GetDomain>::SharedPtr get_domain_client_;
   rclcpp::Client<plansys2_msgs::srv::GetDomainName>::SharedPtr get_name_client_;
   rclcpp::Client<plansys2_msgs::srv::GetDomainTypes>::SharedPtr get_types_client_;
+  rclcpp::Client<plansys2_msgs::srv::GetDomainConstants>::SharedPtr get_constants_client_;
   rclcpp::Client<plansys2_msgs::srv::GetStates>::SharedPtr get_predicates_client_;
   rclcpp::Client<plansys2_msgs::srv::GetStates>::SharedPtr get_functions_client_;
   rclcpp::Client<plansys2_msgs::srv::GetDomainActions>::SharedPtr get_actions_client_;

--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertInterface.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertInterface.hpp
@@ -49,6 +49,13 @@ public:
    */
   virtual std::vector<std::string> getTypes() = 0;
 
+  /// Get the details of a constants existing for a type.
+  /**
+   * \param[in] predicate The name of the type.
+   * \return A list of constants names for the passed type
+   */
+  virtual std::vector<std::string> getConstants(const std::string & type) = 0;
+
   /// Get the predicates existing in the domain.
   /**
    * \return The vector containing the name of the predicates.

--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainReader.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainReader.hpp
@@ -26,6 +26,7 @@ struct Domain
   std::string name;
   std::string requirements;
   std::string types;
+  std::string constants;
   std::string predicates;
   std::string functions;
   std::vector<std::string> actions;
@@ -46,6 +47,7 @@ protected:
   std::string get_name(std::string & domain);
   std::string get_requirements(std::string & domain);
   std::string get_types(const std::string & domain);
+  std::string get_constants(const std::string & domain);
   std::string get_predicates(const std::string & domain);
   std::string get_functions(const std::string & domain);
   std::vector<std::string> get_actions(const std::string & domain);

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpert.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpert.cpp
@@ -62,6 +62,14 @@ DomainExpert::getTypes()
   return ret;
 }
 
+std::vector<std::string>
+DomainExpert::getConstants(const std::string & type)
+{
+  if (!domain_->typed) {return std::vector<std::string>();}
+
+  return domain_->getType(type)->constants.tokens;
+}
+
 std::vector<plansys2::Predicate>
 DomainExpert::getPredicates()
 {

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainReader.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainReader.cpp
@@ -51,6 +51,7 @@ DomainReader::add_domain(const std::string & domain)
   new_domain.name = get_name(lc_domain);
   new_domain.requirements = get_requirements(lc_domain);
   new_domain.types = get_types(lc_domain);
+  new_domain.constants = get_constants(lc_domain);
   new_domain.predicates = get_predicates(lc_domain);
   new_domain.functions = get_functions(lc_domain);
   new_domain.actions = get_actions(lc_domain);
@@ -87,6 +88,14 @@ DomainReader::get_joint_domain() const
   for (auto & domain : domains_) {
     if (!domain.types.empty()) {
       ret += domain.types + "\n";
+    }
+  }
+  ret += ")\n\n";
+
+  ret += "(:constants\n";
+  for (const auto & domain : domains_) {
+    if (!domain.constants.empty()) {
+      ret += domain.constants + "\n";
     }
   }
   ret += ")\n\n";
@@ -218,6 +227,29 @@ DomainReader::get_types(const std::string & domain)
     return "";
   }
 }
+
+
+std::string
+DomainReader::get_constants(const std::string & domain)
+{
+  const std::string pattern(":constants");
+
+  std::size_t init_pos = domain.find(pattern);
+  if (init_pos == std::string::npos) {
+    return "";
+  }
+  init_pos += pattern.length();
+
+  auto end_pos = get_end_block(domain, init_pos);
+
+  if (end_pos >= 0) {
+    std::string ret = substr_without_empty_lines(domain, init_pos, end_pos);
+    return ret;
+  } else {
+    return "";
+  }
+}
+
 
 std::string
 DomainReader::get_predicates(const std::string & domain)

--- a/plansys2_domain_expert/test/pddl/domain_combined_processed.pddl
+++ b/plansys2_domain_expert/test/pddl/domain_combined_processed.pddl
@@ -12,6 +12,9 @@ pickable_object
 room
 )
 
+(:constants
+)
+
 (:predicates
 (object_at_robot ?o - pickable_object ?r - robot)
 (object_at_room ?o - pickable_object ?ro - room)

--- a/plansys2_domain_expert/test/pddl/domain_simple_constants.pddl
+++ b/plansys2_domain_expert/test/pddl/domain_simple_constants.pddl
@@ -1,0 +1,106 @@
+(define (domain plansys2)
+(:requirements :strips :typing :adl :fluents :durative-actions)
+
+;; Types ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(:types
+person  - object 
+message - object
+; This bracket inside a comment, is here for testing purpose :-)
+robot   - object
+room    - object
+teleporter_room - room
+);; end Types ;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(:constants
+leia - robot
+lema - robot
+jack john - person
+)
+;; Predicates ;;;;;;;;;;;;;;;;;;;;;;;;;
+(:predicates
+
+(robot_talk ?r - robot ?m - message ?p - person)
+(robot_near_person ?r - robot ?p - person)
+(robot_at ?r - robot ?ro - room)
+(person_at ?p - person ?ro - room)
+
+);; end Predicates ;;;;;;;;;;;;;;;;;;;;
+;; Functions ;;;;;;;;;;;;;;;;;;;;;;;;;
+(:functions
+    (teleportation_time ?from - teleporter_room ?to - room)
+);; end Functions ;;;;;;;;;;;;;;;;;;;;
+;; Actions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(:durative-action move
+    :parameters (?r - robot ?r1 ?r2 - room)
+    :duration ( = ?duration 5)
+    :condition (and
+        (at start(robot_at ?r ?r1)))
+    :effect (and
+        (at start(not(robot_at ?r ?r1)))
+        (at end(robot_at ?r ?r2))
+    )
+)
+
+
+(:durative-action talk_leia
+    :parameters (?from ?p - person ?m - message)
+    :duration ( = ?duration 5)
+    :condition (and
+        (over all(robot_near_person leia ?p))
+    )
+    :effect (and
+        (at end(robot_talk leia ?m ?p))
+    )
+)
+
+
+(:durative-action talk_lema
+    :parameters (?from ?p - person ?m - message)
+    :duration ( = ?duration 5)
+    :condition (and
+        (over all(robot_near_person lema ?p))
+    )
+    :effect (and
+        (at end(robot_talk lema ?m ?p))
+    )
+)
+
+
+(:durative-action approach
+    :parameters (?r - robot ?ro - room ?p - person)
+    :duration ( = ?duration 5)
+    :condition (and
+        (over all(robot_at ?r ?ro))
+        (over all(person_at ?p ?ro))
+    )
+    :effect (and
+        (at end(robot_near_person ?r ?p))
+    )
+)
+
+
+(:action move_person_john
+    :parameters (?r1 ?r2 - room)
+    :precondition (and 
+        (person_at john ?r1)
+    )
+    :effect (and
+        (person_at john ?r2)
+        (not(person_at john ?r1))
+    )
+)
+
+
+(:action move_person_jack
+    :parameters (?r1 ?r2 - room)
+    :precondition (and 
+        (person_at jack ?r1)
+    )
+    :effect (and
+        (person_at jack ?r2)
+        (not(person_at jack ?r1))
+    )
+)
+
+
+);; end Domain ;;;;;;;;;;;;;;;;;;;;;;;;

--- a/plansys2_domain_expert/test/pddl/domain_simple_constants_processed.pddl
+++ b/plansys2_domain_expert/test/pddl/domain_simple_constants_processed.pddl
@@ -1,0 +1,90 @@
+(define (domain plansys2)
+(:requirements :adl :durative-actions :fluents :strips :typing )
+
+(:types
+person  - object 
+message - object
+robot   - object
+room    - object
+teleporter_room - room
+)
+
+(:constants
+leia - robot
+lema - robot
+jack john - person
+)
+
+(:predicates
+(person_at ?p - person ?ro - room)
+(robot_at ?r - robot ?ro - room)
+(robot_near_person ?r - robot ?p - person)
+(robot_talk ?r - robot ?m - message ?p - person)
+)
+
+(:functions
+    (teleportation_time ?from - teleporter_room ?to - room)
+)
+
+(:durative-action move
+    :parameters (?r - robot ?r1 ?r2 - room)
+    :duration ( = ?duration 5)
+    :condition (and
+        (at start(robot_at ?r ?r1)))
+    :effect (and
+        (at start(not(robot_at ?r ?r1)))
+        (at end(robot_at ?r ?r2))
+    )
+)
+(:durative-action talk_leia
+    :parameters (?from ?p - person ?m - message)
+    :duration ( = ?duration 5)
+    :condition (and
+        (over all(robot_near_person leia ?p))
+    )
+    :effect (and
+        (at end(robot_talk leia ?m ?p))
+    )
+)
+(:durative-action talk_lema
+    :parameters (?from ?p - person ?m - message)
+    :duration ( = ?duration 5)
+    :condition (and
+        (over all(robot_near_person lema ?p))
+    )
+    :effect (and
+        (at end(robot_talk lema ?m ?p))
+    )
+)
+(:durative-action approach
+    :parameters (?r - robot ?ro - room ?p - person)
+    :duration ( = ?duration 5)
+    :condition (and
+        (over all(robot_at ?r ?ro))
+        (over all(person_at ?p ?ro))
+    )
+    :effect (and
+        (at end(robot_near_person ?r ?p))
+    )
+)
+(:action move_person_john
+    :parameters (?r1 ?r2 - room)
+    :precondition (and 
+        (person_at john ?r1)
+    )
+    :effect (and
+        (person_at john ?r2)
+        (not(person_at john ?r1))
+    )
+)
+(:action move_person_jack
+    :parameters (?r1 ?r2 - room)
+    :precondition (and 
+        (person_at jack ?r1)
+    )
+    :effect (and
+        (person_at jack ?r2)
+        (not(person_at jack ?r1))
+    )
+)
+)

--- a/plansys2_domain_expert/test/pddl/domain_simple_processed.pddl
+++ b/plansys2_domain_expert/test/pddl/domain_simple_processed.pddl
@@ -9,6 +9,9 @@ room    - object
 teleporter_room - room
 )
 
+(:constants
+)
+
 (:predicates
 (person_at ?p - person ?ro - room)
 (robot_at ?r - robot ?ro - room)

--- a/plansys2_domain_expert/test/pddl/factory_processed.pddl
+++ b/plansys2_domain_expert/test/pddl/factory_processed.pddl
@@ -8,6 +8,9 @@
 	car - object
 )
 
+(:constants
+)
+
 (:predicates
 	( car_assembled ?car0 - car )
 	( is_assembly_zone ?zone0 - zone )

--- a/plansys2_domain_expert/test/unit/domain_expert_test.cpp
+++ b/plansys2_domain_expert/test/unit/domain_expert_test.cpp
@@ -118,6 +118,23 @@ TEST(domain_expert, get_name)
   ASSERT_EQ(name, test_name);
 }
 
+TEST(domain_expert, get_domain3)
+{
+  std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_domain_expert");
+  std::ifstream domain_ifs(pkgpath + "/pddl/domain_simple_constants.pddl");
+  std::string domain_str((
+      std::istreambuf_iterator<char>(domain_ifs)),
+    std::istreambuf_iterator<char>());
+
+  std::ifstream domain_ifs_p(pkgpath + "/pddl/domain_simple_constants_processed.pddl");
+  std::string domain_str_p((
+      std::istreambuf_iterator<char>(domain_ifs_p)),
+    std::istreambuf_iterator<char>());
+
+  plansys2::DomainExpert domain_expert(domain_str);
+  ASSERT_EQ(domain_expert.getDomain(), domain_str_p);
+}
+
 TEST(domain_expert, get_types)
 {
   std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_domain_expert");

--- a/plansys2_domain_expert/test/unit/domain_expert_test.cpp
+++ b/plansys2_domain_expert/test/unit/domain_expert_test.cpp
@@ -151,6 +151,25 @@ TEST(domain_expert, get_types)
   ASSERT_EQ(types, test_types);
 }
 
+TEST(domain_expert, get_constants)
+{
+  std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_domain_expert");
+  std::ifstream domain_ifs(pkgpath + "/pddl/domain_simple_constants.pddl");
+  std::string domain_str((
+      std::istreambuf_iterator<char>(domain_ifs)),
+    std::istreambuf_iterator<char>());
+
+  plansys2::DomainExpert domain_expert(domain_str);
+
+  std::vector<std::string> consts1 = domain_expert.getConstants("robot");
+  std::vector<std::string> consts2 = domain_expert.getConstants("person");
+  std::vector<std::string> test_consts1 {"leia", "lema"};
+  std::vector<std::string> test_consts2 {"jack", "john"};
+
+  ASSERT_EQ(consts1, test_consts1);
+  ASSERT_EQ(consts2, test_consts2);
+}
+
 TEST(domain_expert, get_predicates)
 {
   std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_domain_expert");

--- a/plansys2_domain_expert/test/unit/domain_reader_test.cpp
+++ b/plansys2_domain_expert/test/unit/domain_reader_test.cpp
@@ -45,6 +45,11 @@ public:
     return get_types(domain);
   }
 
+  std::string get_constants_test(const std::string & domain)
+  {
+    return get_constants(domain);
+  }
+
   std::string get_predicates_test(const std::string & domain)
   {
     return get_predicates(domain);
@@ -219,6 +224,49 @@ TEST(domain_reader, types)
   ASSERT_EQ(res7, req7_estr);
 }
 
+TEST(domain_reader, constants)
+{
+  DomainReaderTest dr;
+
+  std::string req1_str = "(:constants start - location  robotino - robot)";
+  std::string req1_estr = " start - location  robotino - robot";
+
+  std::string req2_str = "(:constants\nstart end - location robotino - robot\n)";
+  std::string req2_estr = "start end - location robotino - robot";
+
+  std::string req3_str = "(:constants\nstart end - location\nrobotino - robot\n)";
+  std::string req3_estr = "start end - location\nrobotino - robot";
+
+  std::string req4_str = "(:constants\nstart end - location\nrobotino - robot\n) )";
+  std::string req4_estr = "start end - location\nrobotino - robot";
+
+  std::string req5_str = "(:constants\nstart end - location\nrobotino - robot\n";
+  std::string req5_estr = "";
+
+  std::string req6_str = "(:constants )";
+  std::string req6_estr = "";
+
+  std::string req7_str = "";
+  std::string req7_estr = "";
+
+  auto res1 = dr.get_constants_test(req1_str);
+  auto res2 = dr.get_constants_test(req2_str);
+  auto res3 = dr.get_constants_test(req3_str);
+  auto res4 = dr.get_constants_test(req4_str);
+  auto res5 = dr.get_constants_test(req5_str);
+  auto res6 = dr.get_constants_test(req6_str);
+  auto res7 = dr.get_constants_test(req7_str);
+
+  ASSERT_EQ(res1, req1_estr);
+  ASSERT_EQ(res2, req2_estr);
+  ASSERT_EQ(res3, req3_estr);
+  ASSERT_EQ(res4, req4_estr);
+  ASSERT_EQ(res5, req5_estr);
+  ASSERT_EQ(res6, req6_estr);
+  ASSERT_EQ(res7, req7_estr);
+}
+
+
 TEST(domain_reader, predicates)
 {
   DomainReaderTest dr;
@@ -373,6 +421,26 @@ TEST(domain_reader, add_2_domain)
 
   dr.add_domain(domain_str);
   dr.add_domain(domain_str_2);
+
+  ASSERT_EQ(dr.get_joint_domain_test(), domain_str_p);
+}
+
+TEST(domain_reader, add_domain_with_constants)
+{
+  DomainReaderTest dr;
+
+  std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_domain_expert");
+  std::ifstream domain_ifs(pkgpath + "/pddl/domain_simple_constants.pddl");
+  std::string domain_str((
+      std::istreambuf_iterator<char>(domain_ifs)),
+    std::istreambuf_iterator<char>());
+
+  std::ifstream domain_ifs_p(pkgpath + "/pddl/domain_simple_constants_processed.pddl");
+  std::string domain_str_p((
+      std::istreambuf_iterator<char>(domain_ifs_p)),
+    std::istreambuf_iterator<char>());
+
+  dr.add_domain(domain_str);
 
   ASSERT_EQ(dr.get_joint_domain_test(), domain_str_p);
 }

--- a/plansys2_msgs/CMakeLists.txt
+++ b/plansys2_msgs/CMakeLists.txt
@@ -31,6 +31,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/GetDomainDurativeActionDetails.srv"
   "srv/GetDomainName.srv"
   "srv/GetDomainTypes.srv"
+  "srv/GetDomainConstants.srv"
   "srv/GetNodeDetails.srv"
   "srv/GetPlan.srv"
   "srv/GetOrderedSubGoals.srv"

--- a/plansys2_msgs/README.md
+++ b/plansys2_msgs/README.md
@@ -192,6 +192,10 @@ The optional parameter list can be used to retrieve an instantiated plan action.
 
 * Returns the domain types.
 
+[`plansys2_msgs::srv::GetDomainConstants`](../plansys2_msgs/srv/GetDomainConstants.srv)
+
+* Returns the domain constants of a type.
+
 [`plansys2_msgs::srv::GetNodeDetails`](../plansys2_msgs/srv/GetNodeDetails.srv)
 
 * Returns a predicate or function node represented as a ([`plansys2_msgs::msg::Node`](../plansys2_msgs/msg/Node.msg)).

--- a/plansys2_msgs/srv/GetDomainConstants.srv
+++ b/plansys2_msgs/srv/GetDomainConstants.srv
@@ -1,0 +1,5 @@
+string type
+---
+bool success
+string[] constants
+string error_info

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Ground.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Ground.cpp
@@ -41,6 +41,10 @@ plansys2_msgs::msg::Node::SharedPtr Ground::getTree( plansys2_msgs::msg::Tree & 
           }
         } else if (d.types[lifted->params[i]]->objects.size() > params[i]) {
           param.name = d.types[lifted->params[i]]->object( params[i] ).first;
+	} else if (params[i] < 0){
+            int type_idx = lifted->params[i];            // idx of the type of this param [ref: d.type]
+            int constant_idx = (-1 * params[i]) -1;      // idx of the constant value [ref: d.type.constant]
+            param.name = d.types[type_idx]->constants[constant_idx]; // the actual constant value
         } else {
           param.name = "?" + std::to_string(params[i]);
         }

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Ground.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Ground.cpp
@@ -28,8 +28,17 @@ plansys2_msgs::msg::Node::SharedPtr Ground::getTree( plansys2_msgs::msg::Tree & 
     node->name = name;
     for ( unsigned i = 0; i < params.size(); ++i ) {
         plansys2_msgs::msg::Param param;
-        if (i < replace.size()) {
-          param.name = replace[params[i]];
+        if (i < replace.size()){
+          if (params[i] >= 0)  // param has a variable value; replace by action-args
+          {
+            param.name = replace[params[i]];
+          }
+           else                // param has a constant value; retrive from domain::type[t_i]::constants[c_i]
+          {
+            int type_idx = lifted->params[i];            // idx of the type of this param [ref: d.type]
+            int constant_idx = (-1 * params[i]) -1;      // idx of the constant value [ref: d.type.constant]
+            param.name = d.types[type_idx]->constants[constant_idx]; // the actual constant value
+          }
         } else if (d.types[lifted->params[i]]->objects.size() > params[i]) {
           param.name = d.types[lifted->params[i]]->object( params[i] ).first;
         } else {

--- a/plansys2_planner/test/pddl/domain_simple_constants.pddl
+++ b/plansys2_planner/test/pddl/domain_simple_constants.pddl
@@ -1,0 +1,106 @@
+(define (domain plansys2)
+(:requirements :strips :typing :adl :fluents :durative-actions)
+
+;; Types ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(:types
+person  - object 
+message - object
+; This bracket inside a comment, is here for testing purpose :-)
+robot   - object
+room    - object
+teleporter_room - room
+);; end Types ;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(:constants
+leia - robot
+lema - robot
+jack john - person
+)
+;; Predicates ;;;;;;;;;;;;;;;;;;;;;;;;;
+(:predicates
+
+(robot_talk ?r - robot ?m - message ?p - person)
+(robot_near_person ?r - robot ?p - person)
+(robot_at ?r - robot ?ro - room)
+(person_at ?p - person ?ro - room)
+
+);; end Predicates ;;;;;;;;;;;;;;;;;;;;
+;; Functions ;;;;;;;;;;;;;;;;;;;;;;;;;
+(:functions
+    (teleportation_time ?from - teleporter_room ?to - room)
+);; end Functions ;;;;;;;;;;;;;;;;;;;;
+;; Actions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(:durative-action move
+    :parameters (?r - robot ?r1 ?r2 - room)
+    :duration ( = ?duration 5)
+    :condition (and
+        (at start(robot_at ?r ?r1)))
+    :effect (and
+        (at start(not(robot_at ?r ?r1)))
+        (at end(robot_at ?r ?r2))
+    )
+)
+
+
+(:durative-action leia_talk
+    :parameters (?from ?p - person ?m - message)
+    :duration ( = ?duration 5)
+    :condition (and
+        (over all(robot_near_person leia ?p))
+    )
+    :effect (and
+        (at end(robot_talk leia ?m ?p))
+    )
+)
+
+
+(:durative-action lema_talk
+    :parameters (?from ?p - person ?m - message)
+    :duration ( = ?duration 5)
+    :condition (and
+        (over all(robot_near_person lema ?p))
+    )
+    :effect (and
+        (at end(robot_talk lema ?m ?p))
+    )
+)
+
+
+(:durative-action approach
+    :parameters (?r - robot ?ro - room ?p - person)
+    :duration ( = ?duration 5)
+    :condition (and
+        (over all(robot_at ?r ?ro))
+        (over all(person_at ?p ?ro))
+    )
+    :effect (and
+        (at end(robot_near_person ?r ?p))
+    )
+)
+
+
+(:action move_person_john
+    :parameters (?r1 ?r2 - room)
+    :precondition (and 
+        (person_at john ?r1)
+    )
+    :effect (and
+        (person_at john ?r2)
+        (not(person_at john ?r1))
+    )
+)
+
+
+(:action move_person_jack
+    :parameters (?r1 ?r2 - room)
+    :precondition (and 
+        (person_at jack ?r1)
+    )
+    :effect (and
+        (person_at jack ?r2)
+        (not(person_at jack ?r1))
+    )
+)
+
+
+);; end Domain ;;;;;;;;;;;;;;;;;;;;;;;;

--- a/plansys2_planner/test/pddl/problem_simple_constants_1.pddl
+++ b/plansys2_planner/test/pddl/problem_simple_constants_1.pddl
@@ -1,0 +1,16 @@
+( define ( problem problem_1 )
+( :domain plansys2 )
+( :objects
+	m1 - message
+	kitchen bedroom - room
+)
+( :init
+	( robot_at leia kitchen )
+	( person_at jack bedroom )
+)
+( :goal
+	( and
+		( robot_talk leia m1 jack )
+	)
+)
+)

--- a/plansys2_planner/test/pddl/problem_simple_constants_2.pddl
+++ b/plansys2_planner/test/pddl/problem_simple_constants_2.pddl
@@ -1,0 +1,18 @@
+( define ( problem problem_1 )
+( :domain plansys2 )
+( :objects
+	jack john - person
+	m1 - message
+	leia lema - robot
+	kitchen bedroom - room
+)
+( :init
+	( robot_at leia kitchen )
+	( person_at jack bedroom )
+)
+( :goal
+	( and
+		( robot_talk leia m1 jack )
+	)
+)
+)

--- a/plansys2_problem_expert/src/plansys2_problem_expert/ProblemExpert.cpp
+++ b/plansys2_problem_expert/src/plansys2_problem_expert/ProblemExpert.cpp
@@ -604,7 +604,13 @@ ProblemExpert::getProblem()
   problem.name = "problem_1";
 
   for (const auto & instance : instances_) {
-    problem.addObject(instance.name, instance.type);
+    bool is_constant = domain.getType(instance.type)->parseConstant(instance.name).first;
+    if (is_constant) {
+      std::cout << "Skipping adding constant as an problem :object: " << instance.name << " " <<
+        instance.type << std::endl;
+    } else {
+      problem.addObject(instance.name, instance.type);
+    }
   }
 
   for (plansys2_msgs::msg::Node predicate : predicates_) {
@@ -693,6 +699,18 @@ ProblemExpert::addProblem(const std::string & problem_str)
   }
 
   std::cout << "Parsed problem: " << problem << std::endl;
+
+  for (unsigned i = 0; i < domain.types.size(); ++i) {
+    if (domain.types[i]->constants.size() ) {
+      for (unsigned j = 0; j < domain.types[i]->constants.size(); ++j) {
+        plansys2::Instance instance;
+        instance.name = domain.types[i]->constants[j];
+        instance.type = domain.types[i]->name;
+        std::cout << "Adding constant: " << instance.name << " " << instance.type << std::endl;
+        addInstance(instance);
+      }
+    }
+  }
 
   for (unsigned i = 0; i < domain.types.size(); ++i) {
     if (domain.types[i]->objects.size() ) {

--- a/plansys2_problem_expert/src/plansys2_problem_expert/ProblemExpert.cpp
+++ b/plansys2_problem_expert/src/plansys2_problem_expert/ProblemExpert.cpp
@@ -382,6 +382,8 @@ ProblemExpert::clearKnowledge()
   instances_.clear();
   predicates_.clear();
   functions_.clear();
+  clearGoal();
+
   return true;
 }
 

--- a/plansys2_problem_expert/test/pddl/domain_simple_constants.pddl
+++ b/plansys2_problem_expert/test/pddl/domain_simple_constants.pddl
@@ -1,0 +1,106 @@
+(define (domain plansys2)
+(:requirements :strips :typing :adl :fluents :durative-actions)
+
+;; Types ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(:types
+person  - object 
+message - object
+; This bracket inside a comment, is here for testing purpose :-)
+robot   - object
+room    - object
+teleporter_room - room
+);; end Types ;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(:constants
+leia - robot
+lema - robot
+jack john - person
+)
+;; Predicates ;;;;;;;;;;;;;;;;;;;;;;;;;
+(:predicates
+
+(robot_talk ?r - robot ?m - message ?p - person)
+(robot_near_person ?r - robot ?p - person)
+(robot_at ?r - robot ?ro - room)
+(person_at ?p - person ?ro - room)
+
+);; end Predicates ;;;;;;;;;;;;;;;;;;;;
+;; Functions ;;;;;;;;;;;;;;;;;;;;;;;;;
+(:functions
+    (teleportation_time ?from - teleporter_room ?to - room)
+);; end Functions ;;;;;;;;;;;;;;;;;;;;
+;; Actions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(:durative-action move
+    :parameters (?r - robot ?r1 ?r2 - room)
+    :duration ( = ?duration 5)
+    :condition (and
+        (at start(robot_at ?r ?r1)))
+    :effect (and
+        (at start(not(robot_at ?r ?r1)))
+        (at end(robot_at ?r ?r2))
+    )
+)
+
+
+(:durative-action leia_talk
+    :parameters (?from ?p - person ?m - message)
+    :duration ( = ?duration 5)
+    :condition (and
+        (over all(robot_near_person leia ?p))
+    )
+    :effect (and
+        (at end(robot_talk leia ?m ?p))
+    )
+)
+
+
+(:durative-action lema_talk
+    :parameters (?from ?p - person ?m - message)
+    :duration ( = ?duration 5)
+    :condition (and
+        (over all(robot_near_person lema ?p))
+    )
+    :effect (and
+        (at end(robot_talk lema ?m ?p))
+    )
+)
+
+
+(:durative-action approach
+    :parameters (?r - robot ?ro - room ?p - person)
+    :duration ( = ?duration 5)
+    :condition (and
+        (over all(robot_at ?r ?ro))
+        (over all(person_at ?p ?ro))
+    )
+    :effect (and
+        (at end(robot_near_person ?r ?p))
+    )
+)
+
+
+(:action move_person_john
+    :parameters (?r1 ?r2 - room)
+    :precondition (and 
+        (person_at john ?r1)
+    )
+    :effect (and
+        (person_at john ?r2)
+        (not(person_at john ?r1))
+    )
+)
+
+
+(:action move_person_jack
+    :parameters (?r1 ?r2 - room)
+    :precondition (and 
+        (person_at jack ?r1)
+    )
+    :effect (and
+        (person_at jack ?r2)
+        (not(person_at jack ?r1))
+    )
+)
+
+
+);; end Domain ;;;;;;;;;;;;;;;;;;;;;;;;

--- a/plansys2_problem_expert/test/pddl/problem_simple_constants_1.pddl
+++ b/plansys2_problem_expert/test/pddl/problem_simple_constants_1.pddl
@@ -1,0 +1,16 @@
+( define ( problem problem_1 )
+( :domain plansys2 )
+( :objects
+	m1 - message
+	kitchen bedroom - room
+)
+( :init
+	( robot_at leia kitchen )
+	( person_at jack bedroom )
+)
+( :goal
+	( and
+		( robot_talk leia m1 jack )
+	)
+)
+)

--- a/plansys2_problem_expert/test/pddl/problem_simple_constants_2.pddl
+++ b/plansys2_problem_expert/test/pddl/problem_simple_constants_2.pddl
@@ -1,0 +1,18 @@
+( define ( problem problem_1 )
+( :domain plansys2 )
+( :objects
+	jack john - person
+	m1 - message
+	leia lema - robot
+	kitchen bedroom - room
+)
+( :init
+	( robot_at leia kitchen )
+	( person_at jack bedroom )
+)
+( :goal
+	( and
+		( robot_talk leia m1 jack )
+	)
+)
+)

--- a/plansys2_problem_expert/test/unit/problem_expert_test.cpp
+++ b/plansys2_problem_expert/test/unit/problem_expert_test.cpp
@@ -635,6 +635,86 @@ TEST(problem_expert, add_problem)
   ASSERT_EQ(problem_expert.getInstances().size(), 0);
 }
 
+
+TEST(problem_expert, add_problem_with_constants)
+{
+  std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_problem_expert");
+  std::ifstream domain_ifs(pkgpath + "/pddl/domain_simple_constants.pddl");
+  std::string domain_str((
+      std::istreambuf_iterator<char>(domain_ifs)),
+    std::istreambuf_iterator<char>());
+
+  auto domain_expert = std::make_shared<plansys2::DomainExpert>(domain_str);
+  plansys2::ProblemExpert problem_expert(domain_expert);
+
+  std::ifstream problem_1_ifs(pkgpath + "/pddl/problem_simple_constants_1.pddl");
+  std::string problem_1_str((
+      std::istreambuf_iterator<char>(problem_1_ifs)),
+    std::istreambuf_iterator<char>());
+  ASSERT_TRUE(problem_expert.addProblem(problem_1_str));
+
+  ASSERT_TRUE(problem_expert.isValidType("robot"));
+  ASSERT_TRUE(problem_expert.isValidType("person"));
+  ASSERT_TRUE(problem_expert.isValidType("room"));
+  ASSERT_TRUE(problem_expert.isValidType("teleporter_room"));
+  ASSERT_TRUE(problem_expert.isValidType("message"));
+
+  ASSERT_EQ(problem_expert.getInstances().size(), 7);
+  ASSERT_EQ(problem_expert.getPredicates().size(), 2);
+  ASSERT_EQ(problem_expert.getFunctions().size(), 0);
+
+  ASSERT_TRUE(problem_expert.existInstance("leia"));
+  ASSERT_TRUE(problem_expert.existInstance("lema"));
+  ASSERT_TRUE(problem_expert.existInstance("jack"));
+  ASSERT_TRUE(problem_expert.existInstance("john"));
+  ASSERT_TRUE(problem_expert.existInstance("kitchen"));
+  ASSERT_TRUE(problem_expert.existInstance("bedroom"));
+  ASSERT_TRUE(problem_expert.existInstance("m1"));
+
+  ASSERT_FALSE(problem_expert.existInstance("r2d2"));
+  ASSERT_FALSE(problem_expert.existInstance("hallway"));
+  ASSERT_FALSE(problem_expert.existInstance("m2"));
+
+  ASSERT_TRUE(
+    problem_expert.existPredicate(
+      parser::pddl::fromStringPredicate(
+        "(robot_at leia kitchen)")));
+  ASSERT_TRUE(
+    problem_expert.existPredicate(
+      parser::pddl::fromStringPredicate(
+        "(person_at jack bedroom)")));
+
+  ASSERT_EQ(parser::pddl::toString(problem_expert.getGoal()), "(and (robot_talk leia m1 jack))");
+
+  ASSERT_EQ(
+    problem_expert.getProblem(),
+    std::string("( define ( problem problem_1 )\n( :domain plansys2 )\n") +
+    std::string("( :objects\n\tm1 - message\n\tkitchen bedroom - room\n)\n") +
+    std::string("( :init\n\t( robot_at leia kitchen )\n\t( person_at jack bedroom )\n)\n") +
+    std::string("( :goal\n\t( and\n\t\t") +
+    std::string("( robot_talk leia m1 jack )\n\t)\n)\n)\n"));
+
+  ASSERT_TRUE(problem_expert.clearKnowledge());
+  ASSERT_EQ(problem_expert.getPredicates().size(), 0);
+  ASSERT_EQ(problem_expert.getFunctions().size(), 0);
+  ASSERT_EQ(problem_expert.getInstances().size(), 0);
+  ASSERT_EQ(
+    problem_expert.getProblem(),
+    std::string("( define ( problem problem_1 )\n( :domain plansys2 )\n") +
+    std::string("( :objects\n)\n( :init\n)\n( :goal\n\t( and\n\t)\n)\n)\n"));
+
+
+  std::ifstream problem_2_ifs(pkgpath + "/pddl/problem_simple_constants_2.pddl");
+  std::string problem_2_str((
+      std::istreambuf_iterator<char>(problem_2_ifs)),
+    std::istreambuf_iterator<char>());
+  ASSERT_TRUE(problem_expert.addProblem(problem_2_str));
+
+  ASSERT_NE(problem_1_str, problem_2_str);
+  ASSERT_NE(problem_expert.getProblem(), problem_2_str);
+  ASSERT_EQ(problem_expert.getProblem(), problem_1_str);
+}
+
 TEST(problem_expert, is_goal_satisfied)
 {
   std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_problem_expert");


### PR DESCRIPTION
This PR fixes handling of pddl domain constants:

Fixes:
[domain_expert] : parsing "(:constants)" from domain_string
[pddl_parser] : Ground::getTree correctly grounds constants values when grounding actions conditions, as well as, when adding predicates
[problem_expert] : 
     - add domain constants as `problem_expert::instances` when adding a problem.pddl from file
     - when generating a problem.pddl file (via `getProblem()`, exclude constants from "(:objects)" . Otherwise, popf will print warnings and failed to generate a plan
```
problem.pddl: line: 4: Warning: Re-declaration of symbol in same scope: jack
problem.pddl: line: 6: Warning: Re-declaration of symbol in same scope: leia

The planner will continue, but you may wish to fix your files accordingly
Constructing lookup tables: [10%] [20%] [30%] [40%] [50%] [60%] [70%] [80%] [90%] [100%] [110%] [120%]
A problem has been encountered, and the problem has been deemed unsolvable
--------------------------------------------------------------------------
The goal fact:
(robot_talk leia m1 jack)

...cannot be found either in the initial state, as an add effect of an
 action, or as a timed initial literal.  As such, the problem has been deemed
unsolvable.
```

Features:
*  [domain_expert] & [msgs] GetDomainConstants service 
* Unit-tests for changes


Minor Fixes unrelated to the constants but caused test failure:
* [problem_expert] also clearing goals upon clearance of knowledge; this caused silent termination of problem_expert node when `getProblem()` was called after a call to `clearKnowledge()`.

Fix #138 , #135
