### PR TITLE
Set rate executor client

### DIFF
--- a/plansys2_bt_actions/test/unit/bt_action_test.cpp
+++ b/plansys2_bt_actions/test/unit/bt_action_test.cpp
@@ -218,7 +218,7 @@ TEST(bt_actions, cancel_bt_action)
   ASSERT_EQ(action_client->get_internal_status(), plansys2::ActionExecutor::Status::RUNNING);
   ASSERT_EQ(bt_action->get_current_state().id(), lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE);
 
-  ASSERT_EQ(action_execution_msgs.size(), 3u);
+  ASSERT_EQ(action_execution_msgs.size(), 4u);
   ASSERT_EQ(action_execution_msgs[0].type, plansys2_msgs::msg::ActionExecution::REQUEST);
   ASSERT_EQ(action_execution_msgs[1].type, plansys2_msgs::msg::ActionExecution::RESPONSE);
   ASSERT_EQ(action_execution_msgs[2].type, plansys2_msgs::msg::ActionExecution::CONFIRM);
@@ -231,7 +231,7 @@ TEST(bt_actions, cancel_bt_action)
     }
   }
 
-  ASSERT_EQ(action_execution_msgs.size(), 4u);
+  ASSERT_EQ(action_execution_msgs.size(), 5u);
   action_client->cancel();
 
   {
@@ -242,7 +242,7 @@ TEST(bt_actions, cancel_bt_action)
       rate.sleep();
     }
   }
-  ASSERT_EQ(action_execution_msgs.size(), 5u);
+  ASSERT_EQ(action_execution_msgs.size(), 6u);
   ASSERT_EQ(action_execution_msgs[3].type, plansys2_msgs::msg::ActionExecution::FEEDBACK);
   ASSERT_EQ(action_execution_msgs[4].type, plansys2_msgs::msg::ActionExecution::CANCEL);
 

--- a/plansys2_bt_actions/test/unit/bt_action_test.cpp
+++ b/plansys2_bt_actions/test/unit/bt_action_test.cpp
@@ -244,7 +244,8 @@ TEST(bt_actions, cancel_bt_action)
   }
   ASSERT_EQ(action_execution_msgs.size(), 6u);
   ASSERT_EQ(action_execution_msgs[3].type, plansys2_msgs::msg::ActionExecution::FEEDBACK);
-  ASSERT_EQ(action_execution_msgs[4].type, plansys2_msgs::msg::ActionExecution::CANCEL);
+  ASSERT_EQ(action_execution_msgs[4].type, plansys2_msgs::msg::ActionExecution::FEEDBACK);
+  ASSERT_EQ(action_execution_msgs[5].type, plansys2_msgs::msg::ActionExecution::CANCEL);
 
   ASSERT_EQ(action_client->get_internal_status(), plansys2::ActionExecutor::Status::CANCELLED);
   ASSERT_EQ(

--- a/plansys2_executor/src/plansys2_executor/ActionExecutorClient.cpp
+++ b/plansys2_executor/src/plansys2_executor/ActionExecutorClient.cpp
@@ -66,9 +66,12 @@ ActionExecutorClient::on_configure(const rclcpp_lifecycle::State & state)
   get_parameter_or<std::vector<std::string>>(
     "specialized_arguments", specialized_arguments_, std::vector<std::string>({}));
 
+
   double rate = 1.0 / std::chrono::duration<double>(rate_).count();
   get_parameter_or("rate", rate, rate);
-  rate_ = rclcpp::Rate(1.0 / rate).period();
+
+  rate_ = std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+    std::chrono::duration<double>(1.0 / rate));
 
   action_hub_pub_ = create_publisher<plansys2_msgs::msg::ActionExecution>(
     "/actions_hub", rclcpp::QoS(100).reliable());

--- a/plansys2_executor/src/plansys2_executor/ActionExecutorClient.cpp
+++ b/plansys2_executor/src/plansys2_executor/ActionExecutorClient.cpp
@@ -37,6 +37,7 @@ ActionExecutorClient::ActionExecutorClient(
 {
   declare_parameter("action_name");
   declare_parameter("specialized_arguments");
+  declare_parameter("rate");
 
   status_.state = plansys2_msgs::msg::ActionPerformerStatus::NOT_READY;
   status_.node_name = get_name();
@@ -65,6 +66,10 @@ ActionExecutorClient::on_configure(const rclcpp_lifecycle::State & state)
   get_parameter_or<std::vector<std::string>>(
     "specialized_arguments", specialized_arguments_, std::vector<std::string>({}));
 
+  double rate = 1.0 / std::chrono::duration<double>(rate_).count();
+  get_parameter_or("rate", rate, rate);
+  rate_ = rclcpp::Rate(1.0 / rate).period();
+
   action_hub_pub_ = create_publisher<plansys2_msgs::msg::ActionExecution>(
     "/actions_hub", rclcpp::QoS(100).reliable());
   action_hub_sub_ = create_subscription<plansys2_msgs::msg::ActionExecution>(
@@ -86,6 +91,8 @@ ActionExecutorClient::on_activate(const rclcpp_lifecycle::State & state)
   status_.state = plansys2_msgs::msg::ActionPerformerStatus::RUNNING;
   timer_ = create_wall_timer(
     rate_, std::bind(&ActionExecutorClient::do_work, this));
+
+  do_work();
 
   return CallbackReturnT::SUCCESS;
 }

--- a/plansys2_executor/test/unit/action_execution_test.cpp
+++ b/plansys2_executor/test/unit/action_execution_test.cpp
@@ -305,7 +305,7 @@ TEST(action_execution, protocol_cancelation)
     move_action_node->get_internal_status().state,
     plansys2_msgs::msg::ActionPerformerStatus::RUNNING);
 
-  ASSERT_EQ(action_execution_msgs.size(), 3u);
+  ASSERT_EQ(action_execution_msgs.size(), 4u);
   ASSERT_EQ(action_execution_msgs[0].type, plansys2_msgs::msg::ActionExecution::REQUEST);
   ASSERT_EQ(action_execution_msgs[1].type, plansys2_msgs::msg::ActionExecution::RESPONSE);
   ASSERT_EQ(action_execution_msgs[2].type, plansys2_msgs::msg::ActionExecution::CONFIRM);
@@ -338,7 +338,7 @@ TEST(action_execution, protocol_cancelation)
     plansys2_msgs::msg::ActionPerformerStatus::READY);
 
 
-  ASSERT_EQ(action_execution_msgs.size(), 6u);
+  ASSERT_EQ(action_execution_msgs.size(), 7u);
   ASSERT_EQ(action_execution_msgs[3].type, plansys2_msgs::msg::ActionExecution::FEEDBACK);
   ASSERT_EQ(action_execution_msgs[4].type, plansys2_msgs::msg::ActionExecution::FEEDBACK);
   ASSERT_EQ(action_execution_msgs[5].type, plansys2_msgs::msg::ActionExecution::CANCEL);

--- a/plansys2_executor/test/unit/action_execution_test.cpp
+++ b/plansys2_executor/test/unit/action_execution_test.cpp
@@ -341,7 +341,8 @@ TEST(action_execution, protocol_cancelation)
   ASSERT_EQ(action_execution_msgs.size(), 7u);
   ASSERT_EQ(action_execution_msgs[3].type, plansys2_msgs::msg::ActionExecution::FEEDBACK);
   ASSERT_EQ(action_execution_msgs[4].type, plansys2_msgs::msg::ActionExecution::FEEDBACK);
-  ASSERT_EQ(action_execution_msgs[5].type, plansys2_msgs::msg::ActionExecution::CANCEL);
+  ASSERT_EQ(action_execution_msgs[5].type, plansys2_msgs::msg::ActionExecution::FEEDBACK);
+  ASSERT_EQ(action_execution_msgs[6].type, plansys2_msgs::msg::ActionExecution::CANCEL);
 
   finish = true;
   t.join();

--- a/plansys2_executor/test/unit/action_execution_test.cpp
+++ b/plansys2_executor/test/unit/action_execution_test.cpp
@@ -189,7 +189,7 @@ TEST(action_execution, protocol_basic)
     move_action_node->get_internal_status().state,
     plansys2_msgs::msg::ActionPerformerStatus::RUNNING);
 
-  ASSERT_EQ(action_execution_msgs.size(), 3u);
+  ASSERT_EQ(action_execution_msgs.size(), 4u);
   ASSERT_EQ(action_execution_msgs[0].type, plansys2_msgs::msg::ActionExecution::REQUEST);
   ASSERT_EQ(action_execution_msgs[1].type, plansys2_msgs::msg::ActionExecution::RESPONSE);
   ASSERT_EQ(action_execution_msgs[2].type, plansys2_msgs::msg::ActionExecution::CONFIRM);


### PR DESCRIPTION
Hi!!

This PR lets you set the rate to execute an `ActionExecutorClient` using a new `rate` parameter. This is useful, for example, in the `bt_action_node`, which was fixed by default to 200ms.

It also forwards the execution of the first iteration of an action one cycle, improving reactivity

Best
