### PR TITLE
Remove invalid goals and keep track of update time in problem expert

### DIFF
--- a/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
+++ b/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
@@ -136,16 +136,16 @@ BTBuilder::get_node_satisfy(
 
   GraphNode::Ptr ret = nullptr;
   std::vector<uint32_t> at_start_effects =
-    parser::pddl::getSubtrees(node->action.action->at_start_effects);
+    parser::pddl::getSubtreeIds(node->action.action->at_start_effects);
   std::vector<uint32_t> at_end_effects =
-    parser::pddl::getSubtrees(node->action.action->at_end_effects);
+    parser::pddl::getSubtreeIds(node->action.action->at_end_effects);
 
   std::vector<uint32_t> at_start_requirements =
-    parser::pddl::getSubtrees(node->action.action->at_start_requirements);
+    parser::pddl::getSubtreeIds(node->action.action->at_start_requirements);
   std::vector<uint32_t> over_all_requirements =
-    parser::pddl::getSubtrees(node->action.action->over_all_requirements);
+    parser::pddl::getSubtreeIds(node->action.action->over_all_requirements);
   std::vector<uint32_t> at_end_requirements =
-    parser::pddl::getSubtrees(node->action.action->at_end_requirements);
+    parser::pddl::getSubtreeIds(node->action.action->at_end_requirements);
 
   for (const auto & effect : at_end_effects) {
     std::pair<std::string, uint8_t> base = get_base(node->action.action->at_end_effects, effect);
@@ -398,11 +398,11 @@ BTBuilder::get_graph(const plansys2_msgs::msg::Plan & current_plan)
     new_node->level_num = level_counter;
 
     std::vector<uint32_t> at_start_requirements =
-      parser::pddl::getSubtrees(action_sequence.begin()->action->at_start_requirements);
+      parser::pddl::getSubtreeIds(action_sequence.begin()->action->at_start_requirements);
     std::vector<uint32_t> over_all_requirements =
-      parser::pddl::getSubtrees(action_sequence.begin()->action->over_all_requirements);
+      parser::pddl::getSubtreeIds(action_sequence.begin()->action->over_all_requirements);
     std::vector<uint32_t> at_end_requirements =
-      parser::pddl::getSubtrees(action_sequence.begin()->action->at_end_requirements);
+      parser::pddl::getSubtreeIds(action_sequence.begin()->action->at_end_requirements);
 
     auto it_at_start = at_start_requirements.begin();
     while (it_at_start != at_start_requirements.end()) {

--- a/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
+++ b/plansys2_executor/src/plansys2_executor/ExecutorNode.cpp
@@ -221,7 +221,7 @@ ExecutorNode::getOrderedSubGoals()
   auto local_functions = problem_client_->getFunctions();
 
   std::vector<plansys2_msgs::msg::Tree> ordered_goals;
-  std::vector<uint32_t> unordered_subgoals = parser::pddl::getSubtrees(goal);
+  std::vector<uint32_t> unordered_subgoals = parser::pddl::getSubtreeIds(goal);
 
   // just in case some goals are already satisfied
   for (auto it = unordered_subgoals.begin(); it != unordered_subgoals.end(); ) {

--- a/plansys2_pddl_parser/include/plansys2_pddl_parser/Utils.h
+++ b/plansys2_pddl_parser/include/plansys2_pddl_parser/Utils.h
@@ -125,7 +125,11 @@ plansys2_msgs::msg::Tree::SharedPtr fromSubtree(const plansys2_msgs::msg::Tree &
 
 plansys2_msgs::msg::Tree::SharedPtr fromSubtrees(const std::vector<plansys2_msgs::msg::Tree> & subtrees, uint8_t node_type);
 
-std::vector<uint32_t> getSubtrees(const plansys2_msgs::msg::Tree & tree);
+std::vector<uint32_t> getSubtreeIds(const plansys2_msgs::msg::Tree & tree);
+
+std::vector<plansys2_msgs::msg::Tree> getSubtrees(const plansys2_msgs::msg::Tree & tree);
+
+void getSubtreeChildren(plansys2_msgs::msg::Tree & subtree, const plansys2_msgs::msg::Tree & tree, uint32_t tree_parent, uint32_t subtree_parent);
 
 void getPredicates(std::vector<plansys2_msgs::msg::Node> & predicates, const plansys2_msgs::msg::Tree & tree, uint32_t node_id = 0, bool negate = false);
 

--- a/plansys2_problem_expert/include/plansys2_problem_expert/ProblemExpert.hpp
+++ b/plansys2_problem_expert/include/plansys2_problem_expert/ProblemExpert.hpp
@@ -76,8 +76,13 @@ private:
     std::shared_ptr<DomainExpert> & domain_expert_,
     uint8_t node_id = 0);
 
-  bool removeFunctionsReferencing(const plansys2_msgs::msg::Param & param);
-  bool removePredicatesReferencing(const plansys2_msgs::msg::Param & param);
+  void removeInvalidPredicates(
+    std::vector<plansys2::Predicate> & predicates,
+    const plansys2::Instance & instance);
+  void removeInvalidFunctions(
+    std::vector<plansys2::Function> & functions,
+    const plansys2::Instance & instance);
+  void removeInvalidGoals(const plansys2::Instance & instance);
 
   std::vector<plansys2::Instance> instances_;
   std::vector<plansys2::Predicate> predicates_;

--- a/plansys2_problem_expert/include/plansys2_problem_expert/ProblemExpertClient.hpp
+++ b/plansys2_problem_expert/include/plansys2_problem_expert/ProblemExpertClient.hpp
@@ -78,6 +78,8 @@ public:
   std::string getProblem();
   bool addProblem(const std::string & problem_str);
 
+  rclcpp::Time getUpdateTime() const {return update_time_;}
+
 private:
   rclcpp::Client<plansys2_msgs::srv::AddProblem>::SharedPtr
     add_problem_client_;
@@ -124,6 +126,7 @@ private:
   rclcpp::Client<plansys2_msgs::srv::IsProblemGoalSatisfied>::SharedPtr
     is_problem_goal_satisfied_client_;
   rclcpp::Node::SharedPtr node_;
+  rclcpp::Time update_time_;
 };
 
 }  // namespace plansys2

--- a/plansys2_problem_expert/src/plansys2_problem_expert/ProblemExpertClient.cpp
+++ b/plansys2_problem_expert/src/plansys2_problem_expert/ProblemExpertClient.cpp
@@ -146,6 +146,7 @@ ProblemExpertClient::addInstance(const plansys2::Instance & instance)
   }
 
   if (future_result.get()->success) {
+    update_time_ = node_->now();
     return true;
   } else {
     RCLCPP_ERROR_STREAM(
@@ -181,6 +182,7 @@ ProblemExpertClient::removeInstance(const plansys2::Instance & instance)
   }
 
   if (future_result.get()->success) {
+    update_time_ = node_->now();
     return true;
   } else {
     RCLCPP_ERROR_STREAM(
@@ -288,6 +290,7 @@ ProblemExpertClient::addPredicate(const plansys2::Predicate & predicate)
   }
 
   if (future_result.get()->success) {
+    update_time_ = node_->now();
     return true;
   } else {
     RCLCPP_ERROR_STREAM(
@@ -323,6 +326,7 @@ ProblemExpertClient::removePredicate(const plansys2::Predicate & predicate)
   }
 
   if (future_result.get()->success) {
+    update_time_ = node_->now();
     return true;
   } else {
     RCLCPP_ERROR_STREAM(
@@ -459,6 +463,7 @@ ProblemExpertClient::addFunction(const plansys2::Function & function)
   }
 
   if (future_result.get()->success) {
+    update_time_ = node_->now();
     return true;
   } else {
     RCLCPP_ERROR_STREAM(
@@ -494,6 +499,7 @@ ProblemExpertClient::removeFunction(const plansys2::Function & function)
   }
 
   if (future_result.get()->success) {
+    update_time_ = node_->now();
     return true;
   } else {
     RCLCPP_ERROR_STREAM(
@@ -555,6 +561,7 @@ bool ProblemExpertClient::updateFunction(const plansys2::Function & function)
   }
 
   if (future_result.get()->success) {
+    update_time_ = node_->now();
     return true;
   } else {
     RCLCPP_ERROR_STREAM(
@@ -664,6 +671,7 @@ ProblemExpertClient::setGoal(const plansys2::Goal & goal)
   }
 
   if (future_result.get()->success) {
+    update_time_ = node_->now();
     return true;
   } else {
     RCLCPP_ERROR_STREAM(
@@ -733,6 +741,7 @@ ProblemExpertClient::clearGoal()
   }
 
   if (future_result.get()->success) {
+    update_time_ = node_->now();
     return true;
   } else {
     RCLCPP_ERROR_STREAM(
@@ -767,6 +776,7 @@ ProblemExpertClient::clearKnowledge()
   }
 
   if (future_result.get()->success) {
+    update_time_ = node_->now();
     return true;
   } else {
     RCLCPP_ERROR_STREAM(
@@ -837,6 +847,7 @@ ProblemExpertClient::addProblem(const std::string & problem_str)
   }
 
   if (future_result.get()->success) {
+    update_time_ = node_->now();
     return true;
   } else {
     RCLCPP_ERROR_STREAM(

--- a/plansys2_problem_expert/test/unit/utils_test.cpp
+++ b/plansys2_problem_expert/test/unit/utils_test.cpp
@@ -852,10 +852,10 @@ TEST(utils, get_subtrees)
   std::vector<uint32_t> empty_expected;
 
   plansys2_msgs::msg::Tree invalid_goal;
-  ASSERT_EQ(parser::pddl::getSubtrees(invalid_goal), empty_expected);
+  ASSERT_EQ(parser::pddl::getSubtreeIds(invalid_goal), empty_expected);
 
   parser::pddl::fromString(invalid_goal, "(or (patrolled wp1) (patrolled wp2))");
-  ASSERT_EQ(parser::pddl::getSubtrees(invalid_goal), empty_expected);
+  ASSERT_EQ(parser::pddl::getSubtreeIds(invalid_goal), empty_expected);
 
   std::vector<uint32_t> expected;
   expected.push_back(1);
@@ -863,7 +863,7 @@ TEST(utils, get_subtrees)
 
   plansys2_msgs::msg::Tree goal;
   parser::pddl::fromString(goal, "(and (patrolled wp1) (patrolled wp2))");
-  auto actual = parser::pddl::getSubtrees(goal);
+  auto actual = parser::pddl::getSubtreeIds(goal);
   ASSERT_EQ(actual.size(), expected.size());
   for (size_t i = 0; i < expected.size(); i++) {
     ASSERT_EQ(actual[i], expected[i]);


### PR DESCRIPTION
There are 2 improvements in this pull request.

1. Remove invalid goals corresponding to a removed problem instance. This was listed as a TODO in the code by @fmrico.
2. Keep track of the update time in the problem expert. One possible use for this is to compare the problem expert update time stamp with the action execution status time stamp. For the action execution status to be relevant (i.e. not outdated), its time stamp should be as new or newer than the problem expert update time stamp.

To test the removal of invalid goals ...

1. Follow the Steps 1-5 of the simple example described here: https://intelligentroboticslab.gsyc.urjc.es/ros2_planning_system.github.io/getting_started/index.html
2. Check the problem goal by entering the command "get problem goal".
3. Remove the instance "bathroom" by entering the command "remove instance bathroom".
4. Verify that the goal has been removed by re-entering the command "get problem goal".