### PR TITLE
Fix bt xml

### DIFF
--- a/plansys2_bringup/launch/plansys2_bringup_launch_distributed.py
+++ b/plansys2_bringup/launch/plansys2_bringup_launch_distributed.py
@@ -102,7 +102,7 @@ def generate_launch_description():
     lifecycle_manager_cmd = Node(
         package='plansys2_lifecycle_manager',
         executable='lifecycle_manager_node',
-        node_name='lifecycle_manager_node',
+        name='lifecycle_manager_node',
         namespace=namespace,
         output='screen',
         parameters=[])

--- a/plansys2_domain_expert/launch/domain_expert_launch.py
+++ b/plansys2_domain_expert/launch/domain_expert_launch.py
@@ -41,8 +41,8 @@ def generate_launch_description():
     # Specify the actions
     domain_expert_cmd = Node(
         package='plansys2_domain_expert',
-        node_executable='domain_expert_node',
-        node_name='domain_expert',
+        executable='domain_expert_node',
+        name='domain_expert',
         namespace=namespace,
         output='screen',
         parameters=[

--- a/plansys2_executor/behavior_trees/plansys2_action_bt.xml
+++ b/plansys2_executor/behavior_trees/plansys2_action_bt.xml
@@ -1,5 +1,6 @@
 <Sequence name="ACTION_ID">
-WAIT_AT_START_ACTIONS
+WAIT_PREV_ACTIONS
+  <WaitAtStartReq action="ACTION_ID"/>
   <ApplyAtStartEffect action="ACTION_ID"/>
   <ReactiveSequence name="ACTION_ID">
     <CheckOverAllReq action="ACTION_ID"/>

--- a/plansys2_executor/launch/executor_launch.py
+++ b/plansys2_executor/launch/executor_launch.py
@@ -45,8 +45,8 @@ def generate_launch_description():
     # Specify the actions
     executor_cmd = Node(
         package='plansys2_executor',
-        node_executable='executor_node',
-        node_name='executor',
+        executable='executor_node',
+        name='executor',
         namespace=namespace,
         output='screen',
         parameters=[

--- a/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
+++ b/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
@@ -46,7 +46,7 @@ BTBuilder::BTBuilder(
   } else {
     bt_action_ =
       R""""(<Sequence name="ACTION_ID">
-WAIT_AT_START_ACTIONS
+WAIT_PREV_ACTIONS
   <ApplyAtStartEffect action="ACTION_ID"/>
   <ReactiveSequence name="ACTION_ID">
     <CheckOverAllReq action="ACTION_ID"/>
@@ -861,7 +861,7 @@ BTBuilder::execution_block(const GraphNode::Ptr & node, int l)
     const std::string parent_action_id = "(" +
       parser::pddl::nameActionsToString(previous_node->action.action) + "):" +
       std::to_string(static_cast<int>( previous_node->action.time * 1000));
-    wait_actions = wait_actions + t(1) + "<WaitAtStartReq action=\"" + parent_action_id + "\"/>";
+    wait_actions = wait_actions + t(1) + "<WaitAction action=\"" + parent_action_id + "\"/>";
 
     if (previous_node != *node->in_arcs.rbegin()) {
       wait_actions = wait_actions + "\n";
@@ -869,7 +869,7 @@ BTBuilder::execution_block(const GraphNode::Ptr & node, int l)
   }
 
   replace(ret_aux, "ACTION_ID", action_id);
-  replace(ret_aux, "WAIT_AT_START_ACTIONS", wait_actions);
+  replace(ret_aux, "WAIT_PREV_ACTIONS", wait_actions);
 
   std::istringstream f(ret_aux);
   std::string line;

--- a/plansys2_executor/src/plansys2_executor/behavior_tree/check_atend_req_node.cpp
+++ b/plansys2_executor/src/plansys2_executor/behavior_tree/check_atend_req_node.cpp
@@ -42,10 +42,18 @@ CheckAtEndReq::tick()
   std::string action;
   getInput("action", action);
 
+  auto node = config().blackboard->get<rclcpp_lifecycle::LifecycleNode::SharedPtr>("node");
+
   auto reqs = (*action_map_)[action].durative_action_info->at_end_requirements;
 
   if (!check(reqs, problem_client_)) {
     (*action_map_)[action].execution_error_info = "Error checking at end requirements";
+
+    RCLCPP_ERROR_STREAM(
+      node->get_logger(),
+      "[" << action << "]" << (*action_map_)[action].execution_error_info << ": " <<
+        parser::pddl::toString((*action_map_)[action].durative_action_info->at_end_requirements));
+
     return BT::NodeStatus::FAILURE;
   } else {
     return BT::NodeStatus::SUCCESS;

--- a/plansys2_executor/src/plansys2_executor/behavior_tree/check_overall_req_node.cpp
+++ b/plansys2_executor/src/plansys2_executor/behavior_tree/check_overall_req_node.cpp
@@ -42,10 +42,18 @@ CheckOverAllReq::tick()
   std::string action;
   getInput("action", action);
 
+  auto node = config().blackboard->get<rclcpp_lifecycle::LifecycleNode::SharedPtr>("node");
+
   auto reqs = (*action_map_)[action].durative_action_info->over_all_requirements;
 
   if (!check(reqs, problem_client_)) {
     (*action_map_)[action].execution_error_info = "Error checking over all requirements";
+
+    RCLCPP_ERROR_STREAM(
+      node->get_logger(),
+      "[" << action << "]" << (*action_map_)[action].execution_error_info << ": " <<
+        parser::pddl::toString((*action_map_)[action].durative_action_info->over_all_requirements));
+
     return BT::NodeStatus::FAILURE;
   } else {
     return BT::NodeStatus::SUCCESS;

--- a/plansys2_executor/src/plansys2_executor/behavior_tree/wait_action_node.cpp
+++ b/plansys2_executor/src/plansys2_executor/behavior_tree/wait_action_node.cpp
@@ -37,15 +37,17 @@ WaitAction::tick()
   std::string action;
   getInput("action", action);
 
-  if ((*action_map_)[action].action_executor == nullptr) {
-    return BT::NodeStatus::RUNNING;
+  if ((*action_map_).find(action) == (*action_map_).end()) {
+    return BT::NodeStatus::RUNNING;  // Not started yet
   }
 
-  if (!(*action_map_)[action].action_executor->is_finished()) {
+  if ((*action_map_)[action].action_executor != nullptr &&
+    (*action_map_)[action].action_executor->is_finished())
+  {
+    return BT::NodeStatus::SUCCESS;
+  } else {
     return BT::NodeStatus::RUNNING;
   }
-
-  return BT::NodeStatus::SUCCESS;
 }
 
 }  // namespace plansys2

--- a/plansys2_executor/src/plansys2_executor/behavior_tree/wait_atstart_req_node.cpp
+++ b/plansys2_executor/src/plansys2_executor/behavior_tree/wait_atstart_req_node.cpp
@@ -42,24 +42,36 @@ WaitAtStartReq::tick()
   std::string action;
   getInput("action", action);
 
-  if ((*action_map_).find(action) == (*action_map_).end()) {
-    return BT::NodeStatus::RUNNING;  // Not started yet
-  }
+  auto node = config().blackboard->get<rclcpp_lifecycle::LifecycleNode::SharedPtr>("node");
 
-  if ((*action_map_)[action].action_executor != nullptr &&
-    (*action_map_)[action].action_executor->is_finished())
-  {
-    return BT::NodeStatus::SUCCESS;
-  }
+  auto reqs_as = (*action_map_)[action].durative_action_info->at_start_requirements;
+  auto reqs_oa = (*action_map_)[action].durative_action_info->over_all_requirements;
 
-  auto reqs = (*action_map_)[action].durative_action_info->at_start_requirements;
+  bool check_as = check(reqs_as, problem_client_);
+  if (!check_as) {
+    (*action_map_)[action].execution_error_info = "Error checking at start reqs";
 
-  if (!check(reqs, problem_client_)) {
-    // ToDo (fmrico): We should add here a timeout
+    RCLCPP_ERROR_STREAM(
+      node->get_logger(),
+      "[" << action << "]" << (*action_map_)[action].execution_error_info << ": " <<
+        parser::pddl::toString((*action_map_)[action].durative_action_info->at_start_requirements));
+
     return BT::NodeStatus::RUNNING;
-  } else {
-    return BT::NodeStatus::SUCCESS;
   }
+
+  bool check_oa = check(reqs_oa, problem_client_);
+  if (!check_oa) {
+    (*action_map_)[action].execution_error_info = "Error checking over all reqs";
+
+    RCLCPP_ERROR_STREAM(
+      node->get_logger(),
+      "[" << action << "]" << (*action_map_)[action].execution_error_info << ": " <<
+        parser::pddl::toString((*action_map_)[action].durative_action_info->over_all_requirements));
+
+    return BT::NodeStatus::RUNNING;
+  }
+
+  return BT::NodeStatus::SUCCESS;
 }
 
 }  // namespace plansys2

--- a/plansys2_executor/test/test_behavior_trees/test_action_timeout_bt.xml
+++ b/plansys2_executor/test/test_behavior_trees/test_action_timeout_bt.xml
@@ -1,5 +1,5 @@
 <Sequence name="ACTION_ID">
-WAIT_AT_START_ACTIONS
+WAIT_PREV_ACTIONS
   <ApplyAtStartEffect action="ACTION_ID"/>
   <ReactiveSequence name="ACTION_ID">
     <CheckTimeout action="ACTION_ID"/>

--- a/plansys2_executor/test/unit/executor_test.cpp
+++ b/plansys2_executor/test/unit/executor_test.cpp
@@ -60,7 +60,7 @@
 #include "gtest/gtest.h"
 
 
-TEST(problem_expert, action_executor_api)
+TEST(executor, action_executor_api)
 {
   auto node = rclcpp_lifecycle::LifecycleNode::make_shared("test_node");
   node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
@@ -195,7 +195,7 @@ public:
   int cycles_;
 };
 
-TEST(problem_expert, action_executor_client)
+TEST(executor, action_executor_client)
 {
   auto test_node = rclcpp_lifecycle::LifecycleNode::make_shared("test_node");
   auto aux_node = rclcpp_lifecycle::LifecycleNode::make_shared("aux_node");
@@ -296,7 +296,7 @@ TEST(problem_expert, action_executor_client)
   t.join();
 }
 
-TEST(problem_expert, action_executor)
+TEST(executor, action_executor)
 {
   auto test_node = rclcpp::Node::make_shared("get_action_from_string");
   auto domain_node = std::make_shared<plansys2::DomainExpertNode>();
@@ -608,7 +608,7 @@ bool CheckAtEndReqTest::halted_ = false;
 bool ApplyAtStartEffectTest::halted_ = false;
 bool ApplyAtEndEffectTest::halted_ = false;
 
-TEST(problem_expert, action_real_action_1)
+TEST(executor, action_real_action_1)
 {
   auto test_node = rclcpp::Node::make_shared("action_real_action_1");
   auto test_lf_node = rclcpp_lifecycle::LifecycleNode::make_shared("test_lf_node");
@@ -682,7 +682,8 @@ TEST(problem_expert, action_real_action_1)
     <root main_tree_to_execute="MainTree">
       <BehaviorTree ID="MainTree">
         <Sequence name="(move r2d2 steering_wheels_zone assembly_zone):0">
-          <WaitAtStartReq action="other"/>
+          <WaitAction action="other"/>
+          <WaitAtStartReq action="(move r2d2 steering_wheels_zone assembly_zone):0"/>
           <ApplyAtStartEffect action="(move r2d2 steering_wheels_zone assembly_zone):0"/>
           <ReactiveSequence name="(move r2d2 steering_wheels_zone assembly_zone):0">
             <CheckOverAllReq action="(move r2d2 steering_wheels_zone assembly_zone):0"/>
@@ -731,7 +732,7 @@ TEST(problem_expert, action_real_action_1)
     for (int i = 0; i < 10; i++) {
       status = tree.tickRoot();
       ASSERT_EQ(status, BT::NodeStatus::RUNNING);
-      ASSERT_EQ(WaitAtStartReqTest::test_status, BT::NodeStatus::RUNNING);
+      ASSERT_EQ(WaitActionTest::test_status, BT::NodeStatus::RUNNING);
     }
   } catch (const std::exception & e) {
     std::cerr << e.what() << '\n';
@@ -742,6 +743,7 @@ TEST(problem_expert, action_real_action_1)
     R"(
     <root main_tree_to_execute="MainTree">
       <BehaviorTree ID="MainTree">
+        <WaitAtStartReq action="(move r2d2 steering_wheels_zone assembly_zone):0"/>
         <Sequence name="(move r2d2 steering_wheels_zone assembly_zone):0">
           <ApplyAtStartEffect action="(move r2d2 steering_wheels_zone assembly_zone):0"/>
           <ReactiveSequence name="(move r2d2 steering_wheels_zone assembly_zone):0">
@@ -861,7 +863,7 @@ TEST(problem_expert, action_real_action_1)
   t.join();
 }
 
-TEST(problem_expert, cancel_bt_execution)
+TEST(executor, cancel_bt_execution)
 {
   auto test_node = rclcpp::Node::make_shared("action_real_action_1");
   auto test_lf_node = rclcpp_lifecycle::LifecycleNode::make_shared("test_lf_node");
@@ -934,6 +936,7 @@ TEST(problem_expert, cancel_bt_execution)
     R"(
     <root main_tree_to_execute="MainTree">
       <BehaviorTree ID="MainTree">
+        <WaitAtStartReq action="(move r2d2 steering_wheels_zone assembly_zone):0"/>
         <Sequence name="(move r2d2 steering_wheels_zone assembly_zone):0">
           <ApplyAtStartEffect action="(move r2d2 steering_wheels_zone assembly_zone):0"/>
           <ReactiveSequence name="(move r2d2 steering_wheels_zone assembly_zone):0">
@@ -1058,7 +1061,7 @@ public:
   bool is_cancelled() {return cancel_plan_requested_;}
 };
 
-TEST(problem_expert, executor_client_execute_plan)
+TEST(executor, executor_client_execute_plan)
 {
   auto test_node_1 = rclcpp::Node::make_shared("test_node_1");
   auto test_node_2 = rclcpp::Node::make_shared("test_node_2");
@@ -1256,7 +1259,7 @@ public:
   int cycles_;
 };
 
-TEST(problem_expert, executor_client_ordered_sub_goals)
+TEST(executor, executor_client_ordered_sub_goals)
 {
   auto test_node_1 = rclcpp::Node::make_shared("test_node_1");
   auto test_node_2 = rclcpp::Node::make_shared("test_node_2");
@@ -1402,7 +1405,7 @@ TEST(problem_expert, executor_client_ordered_sub_goals)
   t.join();
 }
 
-TEST(problem_expert, executor_client_cancel_plan)
+TEST(executor, executor_client_cancel_plan)
 {
   auto test_node_1 = rclcpp::Node::make_shared("test_node_1");
   auto test_node_2 = rclcpp::Node::make_shared("test_node_2");
@@ -1535,7 +1538,7 @@ TEST(problem_expert, executor_client_cancel_plan)
 }
 
 
-TEST(problem_expert, action_timeout)
+TEST(executor, action_timeout)
 {
   auto test_node_1 = rclcpp::Node::make_shared("test_node_1");
   auto test_node_2 = rclcpp::Node::make_shared("test_node_2");

--- a/plansys2_planner/launch/planner_launch.py
+++ b/plansys2_planner/launch/planner_launch.py
@@ -32,8 +32,8 @@ def generate_launch_description():
     # Specify the actions
     planner_cmd = Node(
         package='plansys2_planner',
-        node_executable='planner_node',
-        node_name='planner',
+        executable='planner_node',
+        name='planner',
         namespace=namespace,
         output='screen',
         parameters=[params_file])

--- a/plansys2_problem_expert/launch/problem_expert_launch.py
+++ b/plansys2_problem_expert/launch/problem_expert_launch.py
@@ -41,8 +41,8 @@ def generate_launch_description():
     # Specify the actions
     domain_expert_cmd = Node(
         package='plansys2_problem_expert',
-        node_executable='problem_expert_node',
-        node_name='problem_expert',
+        executable='problem_expert_node',
+        name='problem_expert',
         namespace=namespace,
         output='screen',
         parameters=[{'model_file': model_file}, params_file])


### PR DESCRIPTION
Dear all,

This PR fixes #155 and introduces one change in the resulting BT.

if action `(movetoward cleaner kitchen c_dock):16031` depends on the completion of a previous action `(movetoward cleaner bathroom kitchen):12021`, the resulting BT was:
```
                <Sequence name="(movetoward cleaner kitchen c_dock):16031">
                  <WaitAtStartReq action="(movetoward cleaner bathroom kitchen):12021"/>
                  <ApplyAtStartEffect action="(movetoward cleaner kitchen c_dock):16031"/>
                  <ReactiveSequence name="(movetoward cleaner kitchen c_dock):16031">
                    <CheckOverAllReq action="(movetoward cleaner kitchen c_dock):16031"/>
                    <ExecuteAction action="(movetoward cleaner kitchen c_dock):16031"/>
                  </ReactiveSequence>
                  <CheckAtEndReq action="(movetoward cleaner kitchen c_dock):16031"/>
                  <ApplyAtEndEffect action="(movetoward cleaner kitchen c_dock):16031"/>
                </Sequence>
```

The problem in #155 is that maybe `(movetoward cleaner bathroom kitchen):12021` finished executing, but didn't apply its effects. If `(movetoward cleaner kitchen c_dock):16031` checks these effects, the plan can fail. 

By this PR, the resulting BT is:

```
                <Sequence name="(movetoward cleaner kitchen c_dock):16031">
                  <WaitAction action="(movetoward cleaner bathroom kitchen):12021"/>
                  <WaitAtStartReq action="(movetoward cleaner kitchen c_dock):16031"/>
                  <ApplyAtStartEffect action="(movetoward cleaner kitchen c_dock):16031"/>
                  <ReactiveSequence name="(movetoward cleaner kitchen c_dock):16031">
                    <CheckOverAllReq action="(movetoward cleaner kitchen c_dock):16031"/>
                    <ExecuteAction action="(movetoward cleaner kitchen c_dock):16031"/>
                  </ReactiveSequence>
                  <CheckAtEndReq action="(movetoward cleaner kitchen c_dock):16031"/>
                  <ApplyAtEndEffect action="(movetoward cleaner kitchen c_dock):16031"/>
                </Sequence>
```

That waits for the completion of `(movetoward cleaner bathroom kitchen):12021` and the at start and over all (maybe I should change the name of the BT node, but I didn't want to introduce many changes) requirements of the current action.

I also took the opportunity to update some launcher parameter names. Previous ones were deprecated. 
An also I improved the debug output when the plan fails. Now it displays the cation that fails and why.

Please, @roveri-marco, check if this fix is good for you. @jjzapf, maybe you could also have a look at this.

Best
Francisco 
