### PR TITLE
Remove pthread dependency

### DIFF
--- a/plansys2_core/CMakeLists.txt
+++ b/plansys2_core/CMakeLists.txt
@@ -2,8 +2,6 @@ project(plansys2_core)
 
 cmake_minimum_required(VERSION 3.5)
 
-find_package(Threads REQUIRED)
-
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)


### PR DESCRIPTION
Hi,

Set pthread as a requirement in this package produces [some problems](https://build.ros2.org/job/Gbin_uF64__plansys2_core__ubuntu_focal_amd64__binary/58/) in the ROS packaging system. As this requirement is not really necessary, I am removing it for future packaging.

Best

Signed-off-by: Francisco Martín Rico <fmrico@gmail.com>