### PR TITLE
Minor fixes

### DIFF
--- a/plansys2_problem_expert/src/plansys2_problem_expert/ProblemExpert.cpp
+++ b/plansys2_problem_expert/src/plansys2_problem_expert/ProblemExpert.cpp
@@ -382,6 +382,8 @@ ProblemExpert::clearKnowledge()
   instances_.clear();
   predicates_.clear();
   functions_.clear();
+  clearGoal();
+
   return true;
 }
 

--- a/plansys2_problem_expert/test/unit/problem_expert_test.cpp
+++ b/plansys2_problem_expert/test/unit/problem_expert_test.cpp
@@ -633,6 +633,10 @@ TEST(problem_expert, add_problem)
   ASSERT_EQ(problem_expert.getPredicates().size(), 0);
   ASSERT_EQ(problem_expert.getFunctions().size(), 0);
   ASSERT_EQ(problem_expert.getInstances().size(), 0);
+  ASSERT_EQ(
+    problem_expert.getProblem(),
+    std::string("( define ( problem problem_1 )\n( :domain plansys2 )\n") +
+    std::string("( :objects\n)\n( :init\n)\n( :goal\n\t( and\n\t)\n)\n)\n"));
 }
 
 TEST(problem_expert, is_goal_satisfied)


### PR DESCRIPTION
This PR fixes minor issues with 
* [domain_expert] styling divergence in DomainExpertInterface; this caused errors in running the tests
* [problem_expert] also clearing goals upon clearance of knowledge; this caused silent termination of problem_expert node when `getProblem()` was called after a call to `clearKnowledge()`.

