### PR TITLE
Adding service to retrieve domain name.

### DIFF
--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpert.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpert.hpp
@@ -48,6 +48,12 @@ public:
    */
   void extendDomain(const std::string & domain);
 
+  /// Get the domain name.
+  /**
+   * \return A string containing the domain name.
+   */
+  std::string getName();
+
   /// Get the types existing in the domain.
   /**
    * \return The vector containing the names of the types.

--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertClient.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertClient.hpp
@@ -28,6 +28,7 @@
 #include "plansys2_msgs/msg/node.hpp"
 
 #include "plansys2_msgs/srv/get_domain.hpp"
+#include "plansys2_msgs/srv/get_domain_name.hpp"
 #include "plansys2_msgs/srv/get_domain_types.hpp"
 #include "plansys2_msgs/srv/get_domain_actions.hpp"
 #include "plansys2_msgs/srv/get_domain_action_details.hpp"
@@ -51,6 +52,12 @@ class DomainExpertClient : public DomainExpertInterface
 public:
   /// Create a new DomainExpertClient.
   DomainExpertClient();
+
+  /// Get the domain name.
+  /**
+   * \return A string containing the domain name.
+   */
+  std::string getName();
 
   /// Get the predicates existing in the domain.
   /**
@@ -128,6 +135,7 @@ private:
   rclcpp::Node::SharedPtr node_;
 
   rclcpp::Client<plansys2_msgs::srv::GetDomain>::SharedPtr get_domain_client_;
+  rclcpp::Client<plansys2_msgs::srv::GetDomainName>::SharedPtr get_name_client_;
   rclcpp::Client<plansys2_msgs::srv::GetDomainTypes>::SharedPtr get_types_client_;
   rclcpp::Client<plansys2_msgs::srv::GetStates>::SharedPtr get_predicates_client_;
   rclcpp::Client<plansys2_msgs::srv::GetStates>::SharedPtr get_functions_client_;

--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertInterface.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertInterface.hpp
@@ -37,6 +37,12 @@ public:
    */
   DomainExpertInterface() {}
 
+  /// Get the domain name.
+  /**
+   * \return A string containing the domain name.
+   */
+  virtual std::string getName() = 0;
+
   /// Get the types existing in the domain.
   /**
    * \return The vector containing the names of the types.

--- a/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertNode.hpp
+++ b/plansys2_domain_expert/include/plansys2_domain_expert/DomainExpertNode.hpp
@@ -23,6 +23,7 @@
 #include "std_msgs/msg/string.hpp"
 #include "lifecycle_msgs/msg/state.hpp"
 #include "lifecycle_msgs/msg/transition.hpp"
+#include "plansys2_msgs/srv/get_domain_name.hpp"
 #include "plansys2_msgs/srv/get_domain_types.hpp"
 #include "plansys2_msgs/srv/get_domain_actions.hpp"
 #include "plansys2_msgs/srv/get_domain_action_details.hpp"
@@ -89,6 +90,17 @@ public:
    */
   CallbackReturnT on_error(const rclcpp_lifecycle::State & state);
 
+
+  /// Receives the result of the GetDomainName service call
+  /**
+   * \param[in] request_header The header of the request
+   * \param[in] request The request
+   * \param[out] request The response
+   */
+  void get_domain_name_service_callback(
+    const std::shared_ptr<rmw_request_id_t> request_header,
+    const std::shared_ptr<plansys2_msgs::srv::GetDomainName::Request> request,
+    const std::shared_ptr<plansys2_msgs::srv::GetDomainName::Response> response);
 
   /// Receives the result of the GetDomainTypes service call
   /**
@@ -203,6 +215,7 @@ public:
 private:
   std::shared_ptr<DomainExpert> domain_expert_;
 
+  rclcpp::Service<plansys2_msgs::srv::GetDomainName>::SharedPtr get_name_service_;
   rclcpp::Service<plansys2_msgs::srv::GetDomainTypes>::SharedPtr get_types_service_;
   rclcpp::Service<plansys2_msgs::srv::GetDomainActions>::SharedPtr get_domain_actions_service_;
   rclcpp::Service<plansys2_msgs::srv::GetDomainActionDetails>::SharedPtr

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpert.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpert.cpp
@@ -44,6 +44,12 @@ DomainExpert::extendDomain(const std::string & domain)
   }
 }
 
+std::string
+DomainExpert::getName()
+{
+  return domain_->name;
+}
+
 std::vector<std::string>
 DomainExpert::getTypes()
 {

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertClient.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertClient.cpp
@@ -29,6 +29,8 @@ DomainExpertClient::DomainExpertClient()
 
   get_domain_client_ = node_->create_client<plansys2_msgs::srv::GetDomain>(
     "domain_expert/get_domain");
+  get_name_client_ = node_->create_client<plansys2_msgs::srv::GetDomainName>(
+    "domain_expert/get_domain_name");
   get_types_client_ = node_->create_client<plansys2_msgs::srv::GetDomainTypes>(
     "domain_expert/get_domain_types");
   get_predicates_client_ = node_->create_client<plansys2_msgs::srv::GetStates>(
@@ -50,6 +52,36 @@ DomainExpertClient::DomainExpertClient()
   get_durative_action_details_client_ =
     node_->create_client<plansys2_msgs::srv::GetDomainDurativeActionDetails>(
     "domain_expert/get_domain_durative_action_details");
+}
+
+std::string
+DomainExpertClient::getName()
+{
+  std::string ret;
+
+  while (!get_name_client_->wait_for_service(std::chrono::seconds(1))) {
+    if (!rclcpp::ok()) {
+      return ret;
+    }
+    RCLCPP_INFO_STREAM(
+      node_->get_logger(),
+      get_name_client_->get_service_name() <<
+        " service client: waiting for service to appear...");
+  }
+
+  auto request = std::make_shared<plansys2_msgs::srv::GetDomainName::Request>();
+
+  auto future_result = get_name_client_->async_send_request(request);
+
+  if (rclcpp::spin_until_future_complete(node_, future_result, std::chrono::seconds(1)) !=
+    rclcpp::FutureReturnCode::SUCCESS)
+  {
+    return ret;
+  }
+
+  ret = future_result.get()->name;
+
+  return ret;
 }
 
 std::vector<std::string>

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertNode.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainExpertNode.cpp
@@ -31,6 +31,12 @@ DomainExpertNode::DomainExpertNode()
 {
   declare_parameter("model_file", "");
 
+  get_name_service_ = create_service<plansys2_msgs::srv::GetDomainName>(
+    "domain_expert/get_domain_name",
+    std::bind(
+      &DomainExpertNode::get_domain_name_service_callback,
+      this, std::placeholders::_1, std::placeholders::_2,
+      std::placeholders::_3));
   get_types_service_ = create_service<plansys2_msgs::srv::GetDomainTypes>(
     "domain_expert/get_domain_types",
     std::bind(
@@ -177,6 +183,22 @@ DomainExpertNode::on_error(const rclcpp_lifecycle::State & state)
   RCLCPP_ERROR(get_logger(), "[%s] Error transition", get_name());
 
   return CallbackReturnT::SUCCESS;
+}
+
+void
+DomainExpertNode::get_domain_name_service_callback(
+  const std::shared_ptr<rmw_request_id_t> request_header,
+  const std::shared_ptr<plansys2_msgs::srv::GetDomainName::Request> request,
+  const std::shared_ptr<plansys2_msgs::srv::GetDomainName::Response> response)
+{
+  if (domain_expert_ == nullptr) {
+    response->success = false;
+    response->error_info = "Requesting service in non-active state";
+    RCLCPP_WARN(get_logger(), "Requesting service in non-active state");
+  } else {
+    response->success = true;
+    response->name = domain_expert_->getName();
+  }
 }
 
 void

--- a/plansys2_domain_expert/src/plansys2_domain_expert/DomainReader.cpp
+++ b/plansys2_domain_expert/src/plansys2_domain_expert/DomainReader.cpp
@@ -61,7 +61,15 @@ DomainReader::add_domain(const std::string & domain)
 std::string
 DomainReader::get_joint_domain() const
 {
-  std::string ret = "(define (domain plansys2)\n";
+  std::string ret = "(define (domain ";
+
+  for (size_t i = 0; i < domains_.size(); i++) {
+    ret += domains_[i].name;
+    if (i < domains_.size() - 1) {
+      ret += "_";
+    }
+  }
+  ret += ")\n";
 
   ret += "(:requirements ";
 

--- a/plansys2_domain_expert/test/pddl/domain_combined_processed.pddl
+++ b/plansys2_domain_expert/test/pddl/domain_combined_processed.pddl
@@ -1,4 +1,4 @@
-(define (domain plansys2)
+(define (domain plansys2_plansys2)
 (:requirements :adl :durative-actions :fluents :strips :typing )
 
 (:types

--- a/plansys2_domain_expert/test/pddl/factory_processed.pddl
+++ b/plansys2_domain_expert/test/pddl/factory_processed.pddl
@@ -1,4 +1,4 @@
-(define (domain plansys2)
+(define (domain factory)
 (:requirements :adl :durative-actions :fluents :strips :typing )
 
 (:types

--- a/plansys2_domain_expert/test/unit/domain_expert_test.cpp
+++ b/plansys2_domain_expert/test/unit/domain_expert_test.cpp
@@ -102,6 +102,22 @@ TEST(domain_expert, get_domain2)
   ASSERT_EQ(domain_expert.getDomain(), domain_str_p);
 }
 
+TEST(domain_expert, get_name)
+{
+  std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_domain_expert");
+  std::ifstream domain_ifs(pkgpath + "/pddl/factory.pddl");
+  std::string domain_str((
+      std::istreambuf_iterator<char>(domain_ifs)),
+    std::istreambuf_iterator<char>());
+
+  plansys2::DomainExpert domain_expert(domain_str);
+
+  std::string name = domain_expert.getName();
+  std::string test_name("factory");
+
+  ASSERT_EQ(name, test_name);
+}
+
 TEST(domain_expert, get_types)
 {
   std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_domain_expert");

--- a/plansys2_msgs/CMakeLists.txt
+++ b/plansys2_msgs/CMakeLists.txt
@@ -29,6 +29,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/GetDomainActions.srv"
   "srv/GetDomainActionDetails.srv"
   "srv/GetDomainDurativeActionDetails.srv"
+  "srv/GetDomainName.srv"
   "srv/GetDomainTypes.srv"
   "srv/GetNodeDetails.srv"
   "srv/GetPlan.srv"

--- a/plansys2_msgs/README.md
+++ b/plansys2_msgs/README.md
@@ -184,6 +184,10 @@ If the optional parameter list is not empty it will be used to define the return
 Otherwise, auto-generated values will be used.
 The optional parameter list can be used to retrieve an instantiated plan action.
 
+[`plansys2_msgs::srv::GetDomainName`](../plansys2_msgs/srv/GetDomainName.srv)
+
+* Returns the domain name.
+
 [`plansys2_msgs::srv::GetDomainTypes`](../plansys2_msgs/srv/GetDomainTypes.srv)
 
 * Returns the domain types.

--- a/plansys2_msgs/srv/GetDomainName.srv
+++ b/plansys2_msgs/srv/GetDomainName.srv
@@ -1,0 +1,5 @@
+std_msgs/Empty request
+---
+bool success
+string name
+string error_info

--- a/plansys2_problem_expert/test/unit/problem_expert_test.cpp
+++ b/plansys2_problem_expert/test/unit/problem_expert_test.cpp
@@ -104,7 +104,7 @@ TEST(problem_expert, add_functions)
   ASSERT_EQ(
     problem_expert.getProblem(),
     "( define ( problem problem_1 )\n"
-    "( :domain plansys2 )\n"
+    "( :domain simple )\n"
     "( :objects\n"
     "\tbedroom - room\n"
     "\tkitchen - room_with_teleporter\n"
@@ -138,7 +138,7 @@ TEST(problem_expert, add_functions)
   ASSERT_EQ(
     problem_expert.getProblem(),
     "( define ( problem problem_1 )\n"
-    "( :domain plansys2 )\n"
+    "( :domain simple )\n"
     "( :objects\n"
     "\tbedroom - room\n"
     "\tkitchen - room_with_teleporter\n"
@@ -160,7 +160,7 @@ TEST(problem_expert, add_functions)
   ASSERT_EQ(
     problem_expert.getProblem(),
     "( define ( problem problem_1 )\n"
-    "( :domain plansys2 )\n"
+    "( :domain simple )\n"
     "( :objects\n"
     "\tbedroom - room\n"
     "\tkitchen - room_with_teleporter\n"
@@ -538,7 +538,7 @@ TEST(problem_expert, get_problem)
 
   ASSERT_EQ(
     problem_expert.getProblem(),
-    std::string("( define ( problem problem_1 )\n( :domain plansys2 ") +
+    std::string("( define ( problem problem_1 )\n( :domain simple ") +
     std::string(")\n( :objects\n\tpaco - person\n\tr2d2 - robot\n\tbedroom kitchen - room\n)\n") +
     std::string("( :init\n\t( robot_at r2d2 bedroom )\n\t( robot_at r2d2 kitchen )\n\t( ") +
     std::string("person_at paco bedroom )\n\t( person_at paco kitchen )\n)\n( :goal\n\t( ") +
@@ -623,7 +623,7 @@ TEST(problem_expert, add_problem)
 
   ASSERT_EQ(
     problem_expert.getProblem(),
-    std::string("( define ( problem problem_1 )\n( :domain plansys2 )\n( :objects\n\t") +
+    std::string("( define ( problem problem_1 )\n( :domain simple )\n( :objects\n\t") +
     std::string("jack - person\n\tm1 - message\n\tleia - robot\n\tkitchen bedroom - room\n)\n") +
     std::string("( :init\n\t( robot_at leia kitchen )\n\t( person_at jack bedroom )\n\t") +
     std::string("( = ( room_distance kitchen bedroom ) 10 )\n)\n( :goal\n\t( and\n\t\t") +


### PR DESCRIPTION
In our client software we have specialized code that depends on the domain that is loaded. I've therefore added a service to the domain expert to get the domain name. I trust this will be useful to other users as well.

I've also modified the way that the domain name is generated when combining domains. The previous method was to use "plansys2" for the combined domain name. I've modified this so that the new domain name is a concatenation of the individual domain names separated by underscores.

Finally, I added a unit test to verify the new service.