### PR TITLE
Scientific notation incompatible with PDDL parser

### DIFF
--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/GroundFunc.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/GroundFunc.cpp
@@ -1,4 +1,6 @@
 
+#include <iomanip>
+
 #include "plansys2_pddl_parser/Domain.h"
 
 namespace parser { namespace pddl {
@@ -8,7 +10,7 @@ void GroundFunc<double>::PDDLPrint( std::ostream & s, unsigned indent, const Tok
 	tabindent( s, indent );
 	s << "( = ";
 	TypeGround::PDDLPrint( s, 0, ts, d );
-	s << " " << ( double )value << " )";
+	s << " " << std::fixed << std::setprecision(10) << ( double )value << " )";
 }
 
 template <>

--- a/plansys2_problem_expert/test/unit/problem_expert_test.cpp
+++ b/plansys2_problem_expert/test/unit/problem_expert_test.cpp
@@ -110,7 +110,7 @@ TEST(problem_expert, add_functions)
     "\tkitchen - room_with_teleporter\n"
     ")\n"
     "( :init\n"
-    "\t( = ( room_distance bedroom kitchen ) 1.23 )\n"
+    "\t( = ( room_distance bedroom kitchen ) 1.2300000000 )\n"
     ")\n"
     "( :goal\n"
     "\t( and\n"
@@ -144,8 +144,8 @@ TEST(problem_expert, add_functions)
     "\tkitchen - room_with_teleporter\n"
     ")\n"
     "( :init\n"
-    "\t( = ( room_distance bedroom kitchen ) 1.23 )\n"
-    "\t( = ( room_distance kitchen bedroom ) 2.34 )\n"
+    "\t( = ( room_distance bedroom kitchen ) 1.2300000000 )\n"
+    "\t( = ( room_distance kitchen bedroom ) 2.3400000000 )\n"
     ")\n"
     "( :goal\n"
     "\t( and\n"
@@ -166,8 +166,8 @@ TEST(problem_expert, add_functions)
     "\tkitchen - room_with_teleporter\n"
     ")\n"
     "( :init\n"
-    "\t( = ( room_distance bedroom kitchen ) 1.23 )\n"
-    "\t( = ( room_distance kitchen bedroom ) 3.45 )\n"
+    "\t( = ( room_distance bedroom kitchen ) 1.2300000000 )\n"
+    "\t( = ( room_distance kitchen bedroom ) 3.4500000000 )\n"
     ")\n"
     "( :goal\n"
     "\t( and\n"
@@ -626,8 +626,8 @@ TEST(problem_expert, add_problem)
     std::string("( define ( problem problem_1 )\n( :domain simple )\n( :objects\n\t") +
     std::string("jack - person\n\tm1 - message\n\tleia - robot\n\tkitchen bedroom - room\n)\n") +
     std::string("( :init\n\t( robot_at leia kitchen )\n\t( person_at jack bedroom )\n\t") +
-    std::string("( = ( room_distance kitchen bedroom ) 10 )\n)\n( :goal\n\t( and\n\t\t") +
-    std::string("( robot_talk leia m1 jack )\n\t)\n)\n)\n"));
+    std::string("( = ( room_distance kitchen bedroom ) 10.0000000000 )\n)\n") +
+    std::string("( :goal\n\t( and\n\t\t( robot_talk leia m1 jack )\n\t)\n)\n)\n"));
 
   ASSERT_TRUE(problem_expert.clearKnowledge());
   ASSERT_EQ(problem_expert.getPredicates().size(), 0);


### PR DESCRIPTION
Some of our problems involve large number values. The GroundFunc<double>::PDDLPrint function currently prints these to a string using sceintific notation. Unfortunately, the rest of the system does not seem to parse scientific notation. The simplist solution seems to be to use std::setprecision to ensure that large numbers are printed using decimal form. 