### PR TITLE
action-graph-fix: Using std::list to create action graph rather than …

### DIFF
--- a/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
+++ b/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
@@ -57,8 +57,8 @@ struct GraphNode
   std::vector<plansys2::Predicate> predicates;
   std::vector<plansys2::Function> functions;
 
-  std::set<GraphNode::Ptr> in_arcs;
-  std::set<GraphNode::Ptr> out_arcs;
+  std::list<GraphNode::Ptr> in_arcs;
+  std::list<GraphNode::Ptr> out_arcs;
 };
 
 struct Graph

--- a/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
+++ b/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
@@ -318,7 +318,7 @@ BTBuilder::prune_backwards(GraphNode::Ptr new_node, GraphNode::Ptr node_satisfy)
   auto it = node_satisfy->out_arcs.begin();
   while (it != node_satisfy->out_arcs.end()) {
     if (*it == new_node) {
-      (*it)->in_arcs.erase(*it);
+      (*it)->in_arcs.remove(*it);
       it = node_satisfy->out_arcs.erase(it);
     } else {
       ++it;
@@ -416,8 +416,8 @@ BTBuilder::get_graph(const plansys2_msgs::msg::Plan & current_plan)
         prune_backwards(new_node, node_satisfy);
 
         // Create the connections to the parent node
-        new_node->in_arcs.insert(node_satisfy);
-        node_satisfy->out_arcs.insert(new_node);
+        new_node->in_arcs.push_back(node_satisfy);
+        node_satisfy->out_arcs.push_back(new_node);
 
         // Copy the state from the parent node
         new_node->predicates = node_satisfy->predicates;
@@ -449,8 +449,8 @@ BTBuilder::get_graph(const plansys2_msgs::msg::Plan & current_plan)
         prune_backwards(new_node, node_satisfy);
 
         // Create the connections to the parent node
-        new_node->in_arcs.insert(node_satisfy);
-        node_satisfy->out_arcs.insert(new_node);
+        new_node->in_arcs.push_back(node_satisfy);
+        node_satisfy->out_arcs.push_back(new_node);
 
         // Copy the state from the parent node
         new_node->predicates = node_satisfy->predicates;
@@ -482,8 +482,8 @@ BTBuilder::get_graph(const plansys2_msgs::msg::Plan & current_plan)
         prune_backwards(new_node, node_satisfy);
 
         // Create the connections to the parent node
-        new_node->in_arcs.insert(node_satisfy);
-        node_satisfy->out_arcs.insert(new_node);
+        new_node->in_arcs.push_back(node_satisfy);
+        node_satisfy->out_arcs.push_back(new_node);
 
         // Copy the state from the parent node
         new_node->predicates = node_satisfy->predicates;


### PR DESCRIPTION
There appears to be a small bug in the plan to action graph code. I first noticed this bug when running a “road trip” type scenario where the vehicle is supposed to visit various waypoints. The system would incorrectly create parallel actions. Specifically, a move and a visit action would be scheduled to occur simultaneously. This should not be possible because the move action has an “(at start (not (car_at ?s ?wp1)))” effect, while the visit action has an “(over all (car_at ?s ?wp1))” condition.

Examining the code, I discovered that the planning graph is currently created using a std::set type. However, a std::set does not maintain insertion order. So, graph traversal is not guaranteed to occur in the same order as the graph creation. This appears to lead to some weird consequences when performing the pruning operations. I switched to using a std::list type and I am no longer getting the incorrect parallel actions.

I will create a separate PR to add an action graph generation test using the “road trip” scenario I described above. Without the changes in this PR, that test should fail (assuming your computer behaves the same way as mine). With the changes in this PR, it should pass.