### PR TITLE
Add options to run command in plansys2 Terminal

### DIFF
--- a/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
+++ b/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
@@ -514,8 +514,16 @@ BTBuilder::get_graph(const plansys2_msgs::msg::Plan & current_plan)
       functions);
 
     for (const auto & req : at_start_requirements) {
-      std::cerr << "===> [" << parser::pddl::toString(
+      std::cerr << "[ERROR] at_start_requirement not meet: [" << parser::pddl::toString(
         action_sequence.begin()->action->at_start_requirements, req) << "]" << std::endl;
+    }
+    for (const auto & req : over_all_requirements) {
+      std::cerr << "[ERROR] over_all_requirement not meet: [" << parser::pddl::toString(
+        action_sequence.begin()->action->over_all_requirements, req) << "]" << std::endl;
+    }
+    for (const auto & req : at_end_requirements) {
+      std::cerr << "[ERROR] at_end_requirement not meet: [" << parser::pddl::toString(
+        action_sequence.begin()->action->at_end_requirements, req) << "]" << std::endl;
     }
 
     assert(at_start_requirements.empty());

--- a/plansys2_terminal/include/plansys2_terminal/Terminal.hpp
+++ b/plansys2_terminal/include/plansys2_terminal/Terminal.hpp
@@ -78,7 +78,9 @@ protected:
     std::ostringstream & os);
   virtual void process_remove(std::vector<std::string> & command, std::ostringstream & os);
 
-  virtual void execute_plan();
+  virtual void execute_plan(const plansys2_msgs::msg::Plan & plan);
+  virtual void execute_plan(int items = -1);
+  virtual void execute_action(std::vector<std::string> & command);
   virtual void process_run(std::vector<std::string> & command, std::ostringstream & os);
   virtual void process_check(std::vector<std::string> & command, std::ostringstream & os);
   virtual void process_check_actors(std::vector<std::string> & command, std::ostringstream & os);

--- a/plansys2_terminal/src/plansys2_terminal/Terminal.cpp
+++ b/plansys2_terminal/src/plansys2_terminal/Terminal.cpp
@@ -82,6 +82,7 @@ char * completion_generator(const char * text, int state)
   std::vector<std::string> vocabulary_set{"instance", "predicate", "function", "goal"};
   std::vector<std::string> vocabulary_get{"model", "problem", "domain", "plan"};
   std::vector<std::string> vocabulary_remove{"instance", "predicate", "function", "goal"};
+  std::vector<std::string> vocabulary_run{"action", "num_actions"};
   std::vector<std::string> vocabulary_get_problem{"instances", "predicates", "functions", "goal"};
   std::vector<std::string> vocabulary_get_model{"types", "predicates", "functions", "actions",
     "predicate", "function", "action"};
@@ -108,6 +109,8 @@ char * completion_generator(const char * text, int state)
           current_vocabulary = &vocabulary_get;
         } else if (current_text[0] == "remove") {
           current_vocabulary = &vocabulary_remove;
+        } else if (current_text[0] == "run") {
+          current_vocabulary = &vocabulary_run;
         } else if (current_text[0] == "check") {
           current_vocabulary = &vocabulary_check;
         }
@@ -701,10 +704,8 @@ Terminal::process_remove(std::vector<std::string> & command, std::ostringstream 
 }
 
 void
-Terminal::execute_plan()
+Terminal::execute_plan(int items)
 {
-  rclcpp::Rate loop_rate(5);
-
   auto plan = planner_client_->getPlan(domain_client_->getDomain(), problem_client_->getProblem());
 
   if (!plan.has_value()) {
@@ -712,7 +713,22 @@ Terminal::execute_plan()
     return;
   }
 
-  if (!executor_client_->start_plan_execution(plan.value())) {
+  if (items > 0 && items <= plan.value().items.size()) {
+    plan.value().items.erase(plan.value().items.begin() + items, plan.value().items.end());
+  } else {
+    std::cout << "Can't execute " << items << " actions" << std::endl;
+    return;
+  }
+
+  execute_plan(plan.value());
+}
+
+void
+Terminal::execute_plan(const plansys2_msgs::msg::Plan & plan)
+{
+  rclcpp::Rate loop_rate(5);
+
+  if (!executor_client_->start_plan_execution(plan)) {
     std::cout << "Execution could not start " << std::endl;
     return;
   }
@@ -765,16 +781,55 @@ Terminal::execute_plan()
   }
 }
 
+void
+Terminal::execute_action(std::vector<std::string> & command)
+{
+  std::string complete_action;
+  for (const auto & token : command) {
+    complete_action = complete_action + token + " ";
+  }
+
+  complete_action.pop_back();
+
+  std::cerr << "<[" << complete_action << "]" << std::endl;
+  plansys2_msgs::msg::PlanItem action;
+  action.time = 0.0;
+  action.action = complete_action;
+  action.duration = 1.0;
+
+  plansys2_msgs::msg::Plan single_plan;
+  single_plan.items.push_back(action);
+
+  execute_plan(single_plan);
+}
 
 void
 Terminal::process_run(std::vector<std::string> & command, std::ostringstream & os)
 {
   if (command.size() == 0) {
     execute_plan();
-  }
+  } else {
+    if (command[0] == "action") {
+      pop_front(command);
+      if (!command.empty()) {
+        execute_action(command);
+      }
+    } else if (command[0] == "num_actions") {
+      pop_front(command);
 
-  // ToDo(fmrico): We should be able to run directly an action, for example:
-  // run (move leia entrance dinning)
+      try {
+        int items = std::stoi(command[0]);
+        execute_plan(items);
+      } catch (std::invalid_argument e) {
+        os << e.what() << " with arg: [" << command[0] << "]" << std::endl;
+      }
+    } else {
+      os << "\tUsage: \n\t\trun" << std::endl;
+      os << "\tUsage: \n\t\trun num_actions [number of actions to execute from plan]" <<
+        std::endl;
+      os << "\tUsage: \n\t\trun action [action to execute]" << std::endl;
+    }
+  }
 }
 
 void


### PR DESCRIPTION
Dear all,

Until now, you can run the entire plan by typing: `run` in the plansys2 terminal. I have added two interesting options to the `run` command:
1. `run action [action to run]`: It executes a plan containing only this action. Example:  `run action (move agent carr depot l3)`
2. `run num_actions [N]`. Instead of executing the entire plan, only the first `N` actions of the plan are run. Example: `run num_actions 2`

I hope this will be useful to debug your plans :) 

Best

Signed-off-by: Francisco Martín Rico <fmrico@gmail.com>