### PR TITLE
Fix run entire plan

### DIFF
--- a/plansys2_terminal/src/plansys2_terminal/Terminal.cpp
+++ b/plansys2_terminal/src/plansys2_terminal/Terminal.cpp
@@ -715,7 +715,7 @@ Terminal::execute_plan(int items)
 
   if (items > 0 && items <= plan.value().items.size()) {
     plan.value().items.erase(plan.value().items.begin() + items, plan.value().items.end());
-  } else {
+  } else if (items != -1) {
     std::cout << "Can't execute " << items << " actions" << std::endl;
     return;
   }


### PR DESCRIPTION
Hi,

#192 introduced a small bug that does not let to run the entire map only by typing `run`. This PR fixes it.

Best


Signed-off-by: Francisco Martín Rico <fmrico@gmail.com>