### PR TITLE
Refactor BTActionNode

### DIFF
--- a/plansys2_bt_actions/include/plansys2_bt_actions/BTActionNode.hpp
+++ b/plansys2_bt_actions/include/plansys2_bt_actions/BTActionNode.hpp
@@ -70,7 +70,18 @@ public:
 
     // Make sure the server is actually there before continuing
     RCLCPP_INFO(node_->get_logger(), "Waiting for \"%s\" action server", action_name.c_str());
-    return action_client_->wait_for_action_server(server_timeout_);
+
+    bool success_waiting = action_client_->wait_for_action_server(server_timeout_);
+
+    if (!success_waiting) {
+      RCLCPP_ERROR(
+        node_->get_logger(),
+        "Timeout (%lf secs) waiting for \"%s\" action server",
+        server_timeout_,
+        action_name.c_str());
+    }
+
+    return success_waiting;
   }
 
   // Any subclass of BtActionNode that accepts parameters must provide a providedPorts method

--- a/plansys2_bt_actions/include/plansys2_bt_actions/BTActionNode.hpp
+++ b/plansys2_bt_actions/include/plansys2_bt_actions/BTActionNode.hpp
@@ -81,7 +81,7 @@ public:
         action_name.c_str());
     }
 
-    return true; // success_waiting;
+    return true;  // success_waiting;
   }
 
   // Any subclass of BtActionNode that accepts parameters must provide a providedPorts method

--- a/plansys2_bt_actions/include/plansys2_bt_actions/BTActionNode.hpp
+++ b/plansys2_bt_actions/include/plansys2_bt_actions/BTActionNode.hpp
@@ -81,7 +81,7 @@ public:
         action_name.c_str());
     }
 
-    return success_waiting;
+    return true; // success_waiting;
   }
 
   // Any subclass of BtActionNode that accepts parameters must provide a providedPorts method

--- a/plansys2_bt_actions/include/plansys2_bt_actions/BTActionNode.hpp
+++ b/plansys2_bt_actions/include/plansys2_bt_actions/BTActionNode.hpp
@@ -41,7 +41,7 @@ public:
     node_ = config().blackboard->get<typename NodeT::SharedPtr>("node");
 
     // Get the required items from the blackboard
-    server_timeout_ = 1s;
+    server_timeout_ = 5s;
 
     // Initialize the input and output messages
     goal_ = typename ActionT::Goal();
@@ -81,7 +81,7 @@ public:
       BT::InputPort<std::string>("server_name", "Action server name"),
       BT::InputPort<double>(
         "server_timeout",
-        1.0,
+        5.0,
         "The amount of time to wait for a response from the action server, in seconds")
     };
     basic.insert(addition.begin(), addition.end());
@@ -142,12 +142,12 @@ public:
   {
     // first step to be done only at the beginning of the Action
     if (status() == BT::NodeStatus::IDLE) {
-      double server_timeout = 1.0;
+      double server_timeout = 5.0;
       if (!getInput("server_timeout", server_timeout)) {
         RCLCPP_INFO(
           node_->get_logger(),
           "Missing input port [server_timeout], "
-          "using default value of 1s");
+          "using default value of 5s");
       }
       server_timeout_ = std::chrono::milliseconds(static_cast<int>(server_timeout * 1000.0));
 

--- a/plansys2_bt_actions/include/plansys2_bt_actions/BTActionNode.hpp
+++ b/plansys2_bt_actions/include/plansys2_bt_actions/BTActionNode.hpp
@@ -71,7 +71,9 @@ public:
     // Make sure the server is actually there before continuing
     RCLCPP_INFO(node_->get_logger(), "Waiting for \"%s\" action server", action_name.c_str());
 
+    std::cerr << "=== 1" << std::endl;
     bool success_waiting = action_client_->wait_for_action_server(server_timeout_);
+    std::cerr << "=== 2" << std::endl;
 
     if (!success_waiting) {
       RCLCPP_ERROR(
@@ -80,6 +82,7 @@ public:
         server_timeout_,
         action_name.c_str());
     }
+    std::cerr << "=== 3" << std::endl;
 
     return true;  // success_waiting;
   }

--- a/plansys2_bt_actions/include/plansys2_bt_actions/BTActionNode.hpp
+++ b/plansys2_bt_actions/include/plansys2_bt_actions/BTActionNode.hpp
@@ -71,9 +71,7 @@ public:
     // Make sure the server is actually there before continuing
     RCLCPP_INFO(node_->get_logger(), "Waiting for \"%s\" action server", action_name.c_str());
 
-    std::cerr << "=== 1" << std::endl;
     bool success_waiting = action_client_->wait_for_action_server(server_timeout_);
-    std::cerr << "=== 2" << std::endl;
 
     if (!success_waiting) {
       RCLCPP_ERROR(
@@ -82,9 +80,8 @@ public:
         server_timeout_,
         action_name.c_str());
     }
-    std::cerr << "=== 3" << std::endl;
 
-    return true;  // success_waiting;
+    return success_waiting;
   }
 
   // Any subclass of BtActionNode that accepts parameters must provide a providedPorts method

--- a/plansys2_bt_actions/include/plansys2_bt_actions/BTActionNode.hpp
+++ b/plansys2_bt_actions/include/plansys2_bt_actions/BTActionNode.hpp
@@ -76,8 +76,8 @@ public:
     if (!success_waiting) {
       RCLCPP_ERROR(
         node_->get_logger(),
-        "Timeout (%lf secs) waiting for \"%s\" action server",
-        server_timeout_,
+        "Timeout (%ld secs) waiting for \"%s\" action server",
+        server_timeout_.count() * 1000,
         action_name.c_str());
     }
 

--- a/plansys2_bt_actions/test/behavior_tree/FailureNodes.hpp
+++ b/plansys2_bt_actions/test/behavior_tree/FailureNodes.hpp
@@ -40,10 +40,10 @@ public:
   {
   }
 
-  void on_tick() override
+  BT::NodeStatus on_tick() override
   {
     on_tick_run = true;
-    return_failure_ = true;
+    return BT::NodeStatus::FAILURE;
   }
 
   bool on_tick_run;
@@ -65,13 +65,23 @@ public:
   {
   }
 
+  BT::NodeStatus on_tick() override
+  {
+    if (return_failure) {
+      return BT::NodeStatus::FAILURE;
+    } else {
+      return BT::NodeStatus::RUNNING;
+    }
+  }
+
   void on_feedback(const std::shared_ptr<const Fibonacci::Feedback>) override
   {
     on_feedback_run = true;
-    return_failure_ = true;
+    return_failure = true;
   }
 
   bool on_feedback_run;
+  bool return_failure {false};
 };
 
 }   // namespace plansys2_bt_tests

--- a/plansys2_bt_actions/test/behavior_tree/Move.cpp
+++ b/plansys2_bt_actions/test/behavior_tree/Move.cpp
@@ -61,23 +61,27 @@ Move::Move(
   }
 }
 
-void
+BT::NodeStatus
 Move::on_tick()
 {
-  std::string goal;
-  getInput<std::string>("goal", goal);
+  if (status() == BT::NodeStatus::IDLE) {
+    std::string goal;
+    getInput<std::string>("goal", goal);
 
-  geometry_msgs::msg::Pose2D pose2nav;
-  if (waypoints_.find(goal) != waypoints_.end()) {
-    pose2nav = waypoints_[goal];
-  } else {
-    std::cerr << "No coordinate for waypoint [" << goal << "]" << std::endl;
+    geometry_msgs::msg::Pose2D pose2nav;
+    if (waypoints_.find(goal) != waypoints_.end()) {
+      pose2nav = waypoints_[goal];
+    } else {
+      std::cerr << "No coordinate for waypoint [" << goal << "]" << std::endl;
+    }
+
+    int order_to = 10;
+    goal_.order = order_to;
+
+    setOutput("goal_reached", 0);
   }
 
-  int order_to = 10;
-  goal_.order = order_to;
-
-  setOutput("goal_reached", 0);
+  return BT::NodeStatus::RUNNING;
 }
 
 BT::NodeStatus

--- a/plansys2_bt_actions/test/behavior_tree/Move.hpp
+++ b/plansys2_bt_actions/test/behavior_tree/Move.hpp
@@ -36,7 +36,7 @@ public:
     const std::string & action_name,
     const BT::NodeConfiguration & conf);
 
-  void on_tick() override;
+  BT::NodeStatus on_tick() override;
   BT::NodeStatus on_success() override;
 
   static BT::PortsList providedPorts()

--- a/plansys2_bt_actions/test/unit/bt_action_test.cpp
+++ b/plansys2_bt_actions/test/unit/bt_action_test.cpp
@@ -133,6 +133,7 @@ TEST(bt_actions, load_plugins)
 
 TEST(bt_actions, on_tick_failure)
 {
+  std::cerr << "===================== 1" << std::endl;
   auto node = rclcpp::Node::make_shared("test_node");
   auto move_server_node = std::make_shared<MoveServer>();
   move_server_node->start_server();
@@ -153,29 +154,44 @@ TEST(bt_actions, on_tick_failure)
 
   rclcpp::Rate rate(10);
 
-  BT::NodeStatus status;
-  while (!finished && rclcpp::ok()) {
+  BT::NodeStatus status = BT::NodeStatus::RUNNING;
+  while (rclcpp::ok() && status == BT::NodeStatus::RUNNING) {
+    std::cerr << "=====================" << std::endl;
     status = failure_node.tick();
-    finished = status != BT::NodeStatus::RUNNING;
+
+    if (status == BT::NodeStatus::RUNNING) {
+      std::cerr << "RUNNING" << std::endl;
+    } else if (status == BT::NodeStatus::FAILURE) {
+      std::cerr << "FAILURE" << std::endl;
+    } else {
+      std::cerr << status << std::endl;
+    }
+
+    rclcpp::spin_some(node);
     rate.sleep();
   }
 
   ASSERT_TRUE(failure_node.on_tick_run);
   ASSERT_EQ(status, BT::NodeStatus::FAILURE);
 
+  finished = true;
   t.join();
 }
 
 TEST(bt_actions, on_feedback_failure)
 {
+  std::cerr << "===================== 1" << std::endl;
   auto node = rclcpp::Node::make_shared("test_node");
   auto move_server_node = std::make_shared<MoveServer>();
+  std::cerr << "===================== 2" << std::endl;
   move_server_node->start_server();
+  std::cerr << "===================== 3" << std::endl;
 
   bool finished = false;
   std::thread t([&]() {
       while (!finished) {rclcpp::spin_some(move_server_node);}
     });
+  std::cerr << "===================== 4" << std::endl;
 
 
   BT::NodeConfiguration config;
@@ -184,22 +200,35 @@ TEST(bt_actions, on_feedback_failure)
   bb->set("node", node);
   config.blackboard = bb;
 
+  std::cerr << "===================== 5" << std::endl;
+
   plansys2_bt_tests::OnFeedbackFail failure_node("OnFeedbackFail",
     "move",
     config);
 
   rclcpp::Rate rate(10);
 
-  BT::NodeStatus status;
-  while (!finished && rclcpp::ok()) {
+  BT::NodeStatus status = BT::NodeStatus::RUNNING;
+  while (rclcpp::ok() && status == BT::NodeStatus::RUNNING) {
+    std::cerr << "=====================" << std::endl;
     status = failure_node.tick();
-    finished = status != BT::NodeStatus::RUNNING;
+
+    if (status == BT::NodeStatus::RUNNING) {
+      std::cerr << "RUNNING" << std::endl;
+    } else if (status == BT::NodeStatus::FAILURE) {
+      std::cerr << "FAILURE" << std::endl;
+    } else {
+      std::cerr << status << std::endl;
+    }
+
+    rclcpp::spin_some(node);
     rate.sleep();
   }
 
   ASSERT_TRUE(failure_node.on_feedback_run);
   ASSERT_EQ(status, BT::NodeStatus::FAILURE);
 
+  finished = true;
   t.join();
 }
 

--- a/plansys2_bt_actions/test/unit/bt_action_test.cpp
+++ b/plansys2_bt_actions/test/unit/bt_action_test.cpp
@@ -133,7 +133,6 @@ TEST(bt_actions, load_plugins)
 
 TEST(bt_actions, on_tick_failure)
 {
-  std::cerr << "===================== 1" << std::endl;
   auto node = rclcpp::Node::make_shared("test_node");
   auto move_server_node = std::make_shared<MoveServer>();
   move_server_node->start_server();
@@ -156,16 +155,7 @@ TEST(bt_actions, on_tick_failure)
 
   BT::NodeStatus status = BT::NodeStatus::RUNNING;
   while (rclcpp::ok() && status == BT::NodeStatus::RUNNING) {
-    std::cerr << "=====================" << std::endl;
     status = failure_node.tick();
-
-    if (status == BT::NodeStatus::RUNNING) {
-      std::cerr << "RUNNING" << std::endl;
-    } else if (status == BT::NodeStatus::FAILURE) {
-      std::cerr << "FAILURE" << std::endl;
-    } else {
-      std::cerr << status << std::endl;
-    }
 
     rclcpp::spin_some(node);
     rate.sleep();
@@ -180,27 +170,20 @@ TEST(bt_actions, on_tick_failure)
 
 TEST(bt_actions, on_feedback_failure)
 {
-  std::cerr << "===================== 1" << std::endl;
   auto node = rclcpp::Node::make_shared("test_node");
   auto move_server_node = std::make_shared<MoveServer>();
-  std::cerr << "===================== 2" << std::endl;
   move_server_node->start_server();
-  std::cerr << "===================== 3" << std::endl;
 
   bool finished = false;
   std::thread t([&]() {
       while (!finished) {rclcpp::spin_some(move_server_node);}
     });
-  std::cerr << "===================== 4" << std::endl;
-
 
   BT::NodeConfiguration config;
   BT::assignDefaultRemapping<plansys2_bt_tests::OnFeedbackFail>(config);
   auto bb = BT::Blackboard::create();
   bb->set("node", node);
   config.blackboard = bb;
-
-  std::cerr << "===================== 5" << std::endl;
 
   plansys2_bt_tests::OnFeedbackFail failure_node("OnFeedbackFail",
     "move",
@@ -210,16 +193,7 @@ TEST(bt_actions, on_feedback_failure)
 
   BT::NodeStatus status = BT::NodeStatus::RUNNING;
   while (rclcpp::ok() && status == BT::NodeStatus::RUNNING) {
-    std::cerr << "=====================" << std::endl;
     status = failure_node.tick();
-
-    if (status == BT::NodeStatus::RUNNING) {
-      std::cerr << "RUNNING" << std::endl;
-    } else if (status == BT::NodeStatus::FAILURE) {
-      std::cerr << "FAILURE" << std::endl;
-    } else {
-      std::cerr << status << std::endl;
-    }
 
     rclcpp::spin_some(node);
     rate.sleep();

--- a/plansys2_bt_actions/test/unit/bt_action_test.cpp
+++ b/plansys2_bt_actions/test/unit/bt_action_test.cpp
@@ -207,14 +207,6 @@ TEST(bt_actions, on_feedback_failure)
   while (rclcpp::ok() && status == BT::NodeStatus::RUNNING) {
     status = failure_node.tick();
 
-    if (status == BT::NodeStatus::RUNNING) {
-      std::cerr << "RUNNING" << std::endl;
-    } else if (status == BT::NodeStatus::FAILURE) {
-      std::cerr << "FAILURE" << std::endl;
-    } else {
-      std::cerr << status << std::endl;
-    }
-
     rclcpp::spin_some(node);
     rate.sleep();
   }

--- a/plansys2_bt_actions/test/unit/bt_action_test.cpp
+++ b/plansys2_bt_actions/test/unit/bt_action_test.cpp
@@ -75,6 +75,7 @@ private:
   rclcpp_action::CancelResponse handle_cancel(
     const std::shared_ptr<GoalHandleFibonacci> goal_handle)
   {
+    cancelled_ = true;
     return rclcpp_action::CancelResponse::ACCEPT;
   }
 
@@ -86,12 +87,23 @@ private:
   void execute(const std::shared_ptr<GoalHandleFibonacci> goal_handle)
   {
     auto feedback = std::make_shared<Fibonacci::Feedback>();
-    goal_handle->publish_feedback(feedback);
-    auto result = std::make_shared<Fibonacci::Result>();
 
-    result->sequence.push_back(4);
-    goal_handle->succeed(result);
+    int counter = 0;
+    rclcpp::Rate rate(10);
+    while (rclcpp::ok() && counter++ < 50 && !cancelled_) {  // 5 secs
+      goal_handle->publish_feedback(feedback);
+      rate.sleep();
+    }
+
+    if (!cancelled_) {
+      auto result = std::make_shared<Fibonacci::Result>();
+
+      result->sequence.push_back(4);
+      goal_handle->succeed(result);
+    }
   }
+
+  bool cancelled_ {false};
 };
 
 TEST(bt_actions, load_plugins)

--- a/plansys2_bt_actions/test/unit/bt_action_test.cpp
+++ b/plansys2_bt_actions/test/unit/bt_action_test.cpp
@@ -195,6 +195,14 @@ TEST(bt_actions, on_feedback_failure)
   while (rclcpp::ok() && status == BT::NodeStatus::RUNNING) {
     status = failure_node.tick();
 
+    if (status == BT::NodeStatus::RUNNING) {
+      std::cerr << "RUNNING" << std::endl;
+    } else if (status == BT::NodeStatus::FAILURE) {
+      std::cerr << "FAILURE" << std::endl;
+    } else {
+      std::cerr << status << std::endl;
+    }
+
     rclcpp::spin_some(node);
     rate.sleep();
   }


### PR DESCRIPTION
Hi,

This PR tries to solve issues related to the merge of #178, not solved with #193, and related to #195 .
This is a refactor to #178 and a revert of some functionality that I think is necessary.

An important change in this PR is the `on_tick()` method. Now it is called (as it should be from initial) at each tick, and return a `BT::NodeStatus` that overrides `tick()` operation.

Take a look at this, @sarcasticnature , please
Best

Signed-off-by: Francisco Martín Rico <fmrico@gmail.com>