### PR TITLE
Check reqs

### DIFF
--- a/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
+++ b/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
@@ -373,7 +373,6 @@ BTBuilder::get_graph(const plansys2_msgs::msg::Plan & current_plan)
   auto functions = problem_client_->getFunctions();
 
   graph->roots = get_roots(action_sequence, predicates, functions, node_counter);
-  std::cerr << "Roots = " << graph->roots.size() << std::endl;
 
   // Apply root actions
   for (auto & action_node : graph->roots) {


### PR DESCRIPTION
Hi

This PR is related to #191 and fixes #184.

When creating the graph, the roots (the actions to initiate an execution flow) are identified. They were not correctly identified, because not all the cases were checked to determine if these roots were compatible. Now, if an action requires a predicate which is an effect of another root, or an action produces an effect which is a requisite of another root, it is not considered a root.

Best
Francisco