### PR TITLE
Extend terminal with supporting commands

### DIFF
--- a/plansys2_terminal/include/plansys2_terminal/Terminal.hpp
+++ b/plansys2_terminal/include/plansys2_terminal/Terminal.hpp
@@ -87,6 +87,10 @@ protected:
 
   virtual void process_command(std::string & command, std::ostringstream & os);
 
+		virtual bool process_load(std::vector<std::string> & command, std::ostringstream & os);
+
+		virtual void process_help(std::vector<std::string> & command, std::ostringstream & os);
+
 private:
   std::shared_ptr<plansys2::DomainExpertClient> domain_client_;
   std::shared_ptr<plansys2::ProblemExpertClient> problem_client_;
@@ -94,6 +98,7 @@ private:
   std::shared_ptr<plansys2::ExecutorClient> executor_client_;
 
   std::string problem_file_name_;
+		bool finish_parsing = false;
 };
 
 }  // namespace plansys2_terminal

--- a/plansys2_terminal/include/plansys2_terminal/Terminal.hpp
+++ b/plansys2_terminal/include/plansys2_terminal/Terminal.hpp
@@ -36,6 +36,9 @@ void pop_front(std::vector<std::string> & tokens);
 char * completion_generator(const char * text, int state);
 char ** completer(const char * text, int start, int end);
 
+std::optional<plansys2_msgs::msg::Plan>
+parse_plan(const std::string planfile);
+
 class Terminal : public rclcpp::Node
 {
 public:
@@ -87,7 +90,7 @@ protected:
 
   virtual void process_command(std::string & command, std::ostringstream & os);
 
-		virtual bool process_load(std::vector<std::string> & command, std::ostringstream & os);
+		virtual void process_source(std::vector<std::string> & command, std::ostringstream & os);
 
 		virtual void process_help(std::vector<std::string> & command, std::ostringstream & os);
 
@@ -99,6 +102,7 @@ private:
 
   std::string problem_file_name_;
 		bool finish_parsing = false;
+		bool inside_source = false;
 };
 
 }  // namespace plansys2_terminal

--- a/plansys2_terminal/include/plansys2_terminal/Terminal.hpp
+++ b/plansys2_terminal/include/plansys2_terminal/Terminal.hpp
@@ -90,9 +90,9 @@ protected:
 
   virtual void process_command(std::string & command, std::ostringstream & os);
 
-		virtual void process_source(std::vector<std::string> & command, std::ostringstream & os);
+  virtual void process_source(std::vector<std::string> & command, std::ostringstream & os);
 
-		virtual void process_help(std::vector<std::string> & command, std::ostringstream & os);
+  virtual void process_help(std::vector<std::string> & command, std::ostringstream & os);
 
 private:
   std::shared_ptr<plansys2::DomainExpertClient> domain_client_;
@@ -101,8 +101,8 @@ private:
   std::shared_ptr<plansys2::ExecutorClient> executor_client_;
 
   std::string problem_file_name_;
-		bool finish_parsing = false;
-		bool inside_source = false;
+  bool finish_parsing = false;
+  bool inside_source = false;
 };
 
 }  // namespace plansys2_terminal

--- a/plansys2_terminal/include/plansys2_terminal/Terminal.hpp
+++ b/plansys2_terminal/include/plansys2_terminal/Terminal.hpp
@@ -88,7 +88,11 @@ protected:
   virtual void process_check(std::vector<std::string> & command, std::ostringstream & os);
   virtual void process_check_actors(std::vector<std::string> & command, std::ostringstream & os);
 
-  virtual void process_command(std::string & command, std::ostringstream & os);
+  // Returns false if the processed command is violating some
+  // restriction, e.g. there are nested source commands
+  virtual bool process_command(
+    std::string & command, std::ostringstream & os,
+    bool inside_source = false);
 
   virtual void process_source(std::vector<std::string> & command, std::ostringstream & os);
 
@@ -101,8 +105,6 @@ private:
   std::shared_ptr<plansys2::ExecutorClient> executor_client_;
 
   std::string problem_file_name_;
-  bool finish_parsing = false;
-  bool inside_source = false;
 };
 
 }  // namespace plansys2_terminal

--- a/plansys2_terminal/src/plansys2_terminal/Terminal.cpp
+++ b/plansys2_terminal/src/plansys2_terminal/Terminal.cpp
@@ -78,15 +78,18 @@ char * completion_generator(const char * text, int state)
   static std::vector<std::string> matches;
   static size_t match_index = 0;
 
-  std::vector<std::string> vocabulary{"get", "set", "remove", "run", "check"};
+  std::vector<std::string> vocabulary{"get", "set", "remove", "run",
+    "check", "source", "help", "?", "quit"};
   std::vector<std::string> vocabulary_check{"actors"};
   std::vector<std::string> vocabulary_set{"instance", "predicate", "function", "goal"};
   std::vector<std::string> vocabulary_get{"model", "problem", "domain", "plan"};
   std::vector<std::string> vocabulary_remove{"instance", "predicate", "function", "goal"};
-  std::vector<std::string> vocabulary_run{"action", "num_actions", "planfrom"};
+  std::vector<std::string> vocabulary_run{"action", "num_actions", "plan-file"};
   std::vector<std::string> vocabulary_get_problem{"instances", "predicates", "functions", "goal"};
   std::vector<std::string> vocabulary_get_model{"types", "predicates", "functions", "actions",
     "predicate", "function", "action"};
+  // The help is initialized with all possible commands in the vocabulary
+  std::vector<std::string> vocabulary_help(vocabulary);
 
   if (state == 0) {
     // During initialization, compute the actual matches for 'text' and keep
@@ -114,6 +117,8 @@ char * completion_generator(const char * text, int state)
           current_vocabulary = &vocabulary_run;
         } else if (current_text[0] == "check") {
           current_vocabulary = &vocabulary_check;
+        } else if ((current_text[0] == "help") || (current_text[0] == "?")) {
+          current_vocabulary = &vocabulary_help;
         }
       } else if (current_text.size() == 3) {
         if (current_text[0] == "get" && current_text[1] == "problem") {
@@ -868,7 +873,7 @@ Terminal::process_run(std::vector<std::string> & command, std::ostringstream & o
       } catch (std::invalid_argument e) {
         os << e.what() << " with arg: [" << command[0] << "]" << std::endl;
       }
-    } else if (command[0] == "planfrom") {
+    } else if (command[0] == "plan-file") {
       if (command.size() == 2) {
         std::optional<plansys2_msgs::msg::Plan> plan = parse_plan(command[1]);
         if (!plan.has_value()) {
@@ -883,14 +888,14 @@ Terminal::process_run(std::vector<std::string> & command, std::ostringstream & o
           return;
         }
       } else {
-        os << "\tUsage: \n\t\trun planfrom [planfile]" << std::endl;
+        os << "\tUsage: \n\t\trun plan-file [planfile]" << std::endl;
       }
     } else {
       os << "\tUsage: \n\t\trun" << std::endl;
       os << "\tUsage: \n\t\trun num_actions [number of actions to execute from plan]" <<
         std::endl;
       os << "\tUsage: \n\t\trun action [action to execute]" << std::endl;
-      os << "\tUsage: \n\t\trun planfrom [planfile]" << std::endl;
+      os << "\tUsage: \n\t\trun plan-file [planfile]" << std::endl;
     }
   }
 }
@@ -978,7 +983,7 @@ Terminal::process_help(std::vector<std::string> & command, std::ostringstream & 
   std::ostringstream cmd_run;
   cmd_run << "\t run action <action>" << std::endl <<
     "\t run num_actions <num>" << std::endl <<
-    "\t run planfrom <planfile>" << std::endl;
+    "\t run plan-file <planfile>" << std::endl;
 
   std::ostringstream cmd_check;
   cmd_check << "\t check [actors]" << std::endl;

--- a/plansys2_terminal/src/plansys2_terminal/Terminal.cpp
+++ b/plansys2_terminal/src/plansys2_terminal/Terminal.cpp
@@ -25,6 +25,7 @@
 #include <sstream>
 #include <fstream>
 #include <map>
+#include <utility>
 
 #include "rclcpp/rclcpp.hpp"
 
@@ -160,16 +161,16 @@ char ** completer(const char * text, int start, int end)
 std::optional<plansys2_msgs::msg::Plan>
 parse_plan(const std::string planfile)
 {
-		std::ifstream plan_file(planfile, std::ifstream::in);
-		if (plan_file.fail()) {
-				std::cerr << "Unable to open plan file \"" << planfile
-													<< "\" for reading!" << std::endl;
-				return {};
-		}
+  std::ifstream plan_file(planfile, std::ifstream::in);
+  if (plan_file.fail()) {
+    std::cerr << "Unable to open plan file \"" << planfile <<
+      "\" for reading!" << std::endl;
+    return {};
+  }
 
-		plansys2_msgs::msg::Plan ret;
+  plansys2_msgs::msg::Plan ret;
   if (plan_file.is_open()) {
-				std::string line;
+    std::string line;
     while (getline(plan_file, line)) {
       plansys2_msgs::msg::PlanItem item;
       size_t colon_pos = line.find(":");
@@ -189,14 +190,14 @@ parse_plan(const std::string planfile)
       ret.items.push_back(item);
     }
     plan_file.close();
-				std::cout << "The plan read from \""<< planfile << "\" is " << std::endl;
-				for (const auto & plan_item : ret.items) {
-						std::cout << plan_item.time << ":\t" << plan_item.action << "\t["
-																<< plan_item.duration << "]" << std::endl;
-				}
+    std::cout << "The plan read from \"" << planfile << "\" is " << std::endl;
+    for (const auto & plan_item : ret.items) {
+      std::cout << plan_item.time << ":\t" << plan_item.action <<
+        "\t[" << plan_item.duration << "]" << std::endl;
+    }
   }
 
-		if (ret.items.empty()) {
+  if (ret.items.empty()) {
     return {};
   } else {
     return ret;
@@ -652,7 +653,7 @@ Terminal::process_remove_instance(std::vector<std::string> & command, std::ostri
 void
 Terminal::process_remove_predicate(std::vector<std::string> & command, std::ostringstream & os)
 {
-		const std::string rem_pred_cmd =  "\tUsage: \n\t\tremove predicate (predicate)";
+  const std::string rem_pred_cmd = "\tUsage: \n\t\tremove predicate (predicate)";
   if (command.size() > 0) {
     plansys2::Predicate predicate;
     predicate.node_type = plansys2_msgs::msg::Node::PREDICATE;
@@ -678,8 +679,8 @@ Terminal::process_remove_predicate(std::vector<std::string> & command, std::ostr
     predicate.parameters.back().name.pop_back();  // Remove last (
 
     if (!problem_client_->removePredicate(predicate)) {
-      os << "Could not remove the predicate [" << parser::pddl::toString(predicate) << "]"
-									<< std::endl;
+      os << "Could not remove the predicate [" << parser::pddl::toString(predicate) <<
+        "]" << std::endl;
     }
   } else {
     os << rem_pred_cmd << std::endl;
@@ -868,24 +869,23 @@ Terminal::process_run(std::vector<std::string> & command, std::ostringstream & o
         os << e.what() << " with arg: [" << command[0] << "]" << std::endl;
       }
     } else if (command[0] == "planfrom") {
-						if (command.size() == 2) {
-								std::optional<plansys2_msgs::msg::Plan> plan = parse_plan(command[1]);
-								if (!plan.has_value()) {
-										os << "Plan could not be loaded " << std::endl;
-										return;
-								}
-								try {
-										execute_plan(plan.value());
-								} catch (std::invalid_argument e) {
-										os << e.what() << " with arg: [" << command[0]
-													<< command[1] << "]" << std::endl;
-										return;
-								}
-						}
-						else {
-								os << "\tUsage: \n\t\trun planfrom [planfile]" << std::endl;
-						}
-				} else {
+      if (command.size() == 2) {
+        std::optional<plansys2_msgs::msg::Plan> plan = parse_plan(command[1]);
+        if (!plan.has_value()) {
+          os << "Plan could not be loaded " << std::endl;
+          return;
+        }
+        try {
+          execute_plan(plan.value());
+        } catch (std::invalid_argument e) {
+          os << e.what() << " with arg: [" << command[0] <<
+            command[1] << "]" << std::endl;
+          return;
+        }
+      } else {
+        os << "\tUsage: \n\t\trun planfrom [planfile]" << std::endl;
+      }
+    } else {
       os << "\tUsage: \n\t\trun" << std::endl;
       os << "\tUsage: \n\t\trun num_actions [number of actions to execute from plan]" <<
         std::endl;
@@ -957,113 +957,108 @@ Terminal::process_check(std::vector<std::string> & command, std::ostringstream &
 void
 Terminal::process_help(std::vector<std::string> & command, std::ostringstream & os)
 {
-		std::ostringstream cmd_set;
-		cmd_set << "\t set instance <object> <type>" << std::endl
-										<< "\t set predicate <predicate>" << std::endl
-										<< "\t set function (= <function> <value>)" << std::endl
-										<< "\t set goal <goal_formula>" << std::endl;
-		std::ostringstream cmd_get;
-		cmd_get << "\t get model   types | predicates | functions | actions |"<< std::endl
-										<< "\t             predicate <predicate_name> | function <function_name> |"<< std::endl
-										<< "\t             action <action_name> " << std::endl
-										<< "\t get problem  instances | predicates | functions | goal " << std::endl
-										<< "\t get domain" << std::endl
-										<< "\t get plan" << std::endl;
-		std::ostringstream cmd_rem;
-		cmd_rem << "\t remove instance <object>" << std::endl
-										<< "\t remove predicate <predicate>" << std::endl
-										<< "\t remove function <function>" << std::endl
-										<< "\t remove goal" << std::endl;
+  std::ostringstream cmd_set;
+  cmd_set << "\t set instance <object> <type>" << std::endl <<
+    "\t set predicate <predicate>" << std::endl <<
+    "\t set function (= <function> <value>)" << std::endl <<
+    "\t set goal <goal_formula>" << std::endl;
+  std::ostringstream cmd_get;
+  cmd_get << "\t get model   types | predicates | functions | actions |" << std::endl <<
+    "\t             predicate <predicate_name> | function <function_name> |" << std::endl <<
+    "\t             action <action_name> " << std::endl <<
+    "\t get problem  instances | predicates | functions | goal " << std::endl <<
+    "\t get domain" << std::endl <<
+    "\t get plan" << std::endl;
+  std::ostringstream cmd_rem;
+  cmd_rem << "\t remove instance <object>" << std::endl <<
+    "\t remove predicate <predicate>" << std::endl <<
+    "\t remove function <function>" << std::endl <<
+    "\t remove goal" << std::endl;
 
-		std::ostringstream cmd_run;
-		cmd_run << "\t run action <action>" << std::endl
-										<< "\t run num_actions <num>" << std::endl
-										<< "\t run planfrom <planfile>" << std::endl;
+  std::ostringstream cmd_run;
+  cmd_run << "\t run action <action>" << std::endl <<
+    "\t run num_actions <num>" << std::endl <<
+    "\t run planfrom <planfile>" << std::endl;
 
-		std::ostringstream cmd_check;
-		cmd_check << "\t check [actors]" << std::endl;
+  std::ostringstream cmd_check;
+  cmd_check << "\t check [actors]" << std::endl;
 
-		std::ostringstream cmd_source;
-		cmd_source << "\t source <file_name> [0|1]" << std::endl;
+  std::ostringstream cmd_source;
+  cmd_source << "\t source <file_name> [0|1]" << std::endl;
 
-		std::ostringstream cmd_help;
-		cmd_help << "\t help|? [ set | get | remove | run | check | source | quit | help | ? ]" << std::endl;
+  std::ostringstream cmd_help;
+  cmd_help << "\t help|? [ set | get | remove | run | check |" <<
+    " source | quit | help | ? ]" << std::endl;
 
-		std::map<std::string,std::string> cmds;
-		cmds.insert(std::pair<std::string,std::string>("set", cmd_set.str()));
-		cmds.insert(std::pair<std::string,std::string>("get", cmd_get.str()));
-		cmds.insert(std::pair<std::string,std::string>("remove", cmd_rem.str()));
-		cmds.insert(std::pair<std::string,std::string>("run", cmd_run.str()));
-		cmds.insert(std::pair<std::string,std::string>("check", cmd_run.str()));
-		cmds.insert(std::pair<std::string,std::string>("source", cmd_source.str()));
-		cmds.insert(std::pair<std::string,std::string>("quit", std::string("")));
-		cmds.insert(std::pair<std::string,std::string>("help", cmd_help.str()));
-		cmds.insert(std::pair<std::string,std::string>("?", cmd_help.str()));
+  std::map<std::string, std::string> cmds;
+  cmds.insert(std::pair<std::string, std::string>("set", cmd_set.str()));
+  cmds.insert(std::pair<std::string, std::string>("get", cmd_get.str()));
+  cmds.insert(std::pair<std::string, std::string>("remove", cmd_rem.str()));
+  cmds.insert(std::pair<std::string, std::string>("run", cmd_run.str()));
+  cmds.insert(std::pair<std::string, std::string>("check", cmd_run.str()));
+  cmds.insert(std::pair<std::string, std::string>("source", cmd_source.str()));
+  cmds.insert(std::pair<std::string, std::string>("quit", std::string("")));
+  cmds.insert(std::pair<std::string, std::string>("help", cmd_help.str()));
+  cmds.insert(std::pair<std::string, std::string>("?", cmd_help.str()));
 
   if (command.empty()) {
-				os << "The list of available commands is the following:" << std::endl;
-				for (auto it1 = cmds.begin(); it1 != cmds.end(); it1++) {
-						os << it1->first << std::endl
-									<< it1->second << std::endl;
-				}
-				return;
+    os << "The list of available commands is the following:" << std::endl;
+    for (auto it1 = cmds.begin(); it1 != cmds.end(); it1++) {
+      os << it1->first << std::endl << it1->second << std::endl;
+    }
+    return;
   }
 
-		const std::string c = command[0];
-		auto cmd = cmds.find(c);
-		if (cmd != cmds.end()) {
-				os << cmd->first << std::endl;
-				os << cmd->second << std::endl;
-				return;
-		}
-		os << "Command \"" << command[0] << "\" command not found" << std::endl;
-		return;
+  const std::string c = command[0];
+  auto cmd = cmds.find(c);
+  if (cmd != cmds.end()) {
+    os << cmd->first << std::endl;
+    os << cmd->second << std::endl;
+    return;
+  }
+  os << "Command \"" << command[0] << "\" command not found" << std::endl;
 }
 
 void
 Terminal::process_source(std::vector<std::string> & command, std::ostringstream & os)
 {
-		const std::string cmd_help = "\tUsage: \n\t\tsource <filename> [0|1]";
+  const std::string cmd_help = "\tUsage: \n\t\tsource <filename> [0|1]";
 
-  if (command.empty() || command.size() > 2 ||
-						command[0].empty()) {
-				os << cmd_help << std::endl;
-				return;
-		}
+  if (command.empty() || command.size() > 2 || command[0].empty()) {
+    os << cmd_help << std::endl;
+    return;
+  }
 
-		std::string cmdfile = command[0];
-		bool do_echo = false;
-		if (command.size() == 2) {
-				if (command[1] == "0") {
-						do_echo = false;
-				} else if (command[1] == "1") {
-						do_echo = true;
-				} else {
-						os << cmd_help << std::endl;
-						return;
-				}
-		}
+  std::string cmdfile = command[0];
+  bool do_echo = false;
+  if (command.size() == 2) {
+    if (command[1] == "0") {
+      do_echo = false;
+    } else if (command[1] == "1") {
+      do_echo = true;
+    } else {
+      os << cmd_help << std::endl;
+      return;
+    }
+  }
 
-		std::ifstream cmd_ifs(cmdfile, std::ifstream::in);
-		if (cmd_ifs.fail()) {
-				os << "\tFailing to open file \"" << cmdfile << "\"" << std::endl;
-				return;
-		}
+  std::ifstream cmd_ifs(cmdfile, std::ifstream::in);
+  if (cmd_ifs.fail()) {
+    os << "\tFailing to open file \"" << cmdfile << "\"" << std::endl;
+    return;
+  }
 
-		finish_parsing = false;
-		std::string ln;
-  while (!finish_parsing &&
-									std::getline(cmd_ifs, ln, '\n')) {
-				clean_command(ln);
-				std::ostringstream os;
-				if (do_echo) os << ln << std::endl;
-				process_command(ln, os);
-				std::cout << os.str();
-		}
+  finish_parsing = false;
+  std::string ln;
+  while (!finish_parsing && std::getline(cmd_ifs, ln, '\n')) {
+    clean_command(ln);
+    std::ostringstream os;
+    if (do_echo) {os << ln << std::endl;}
+    process_command(ln, os);
+    std::cout << os.str();
+  }
 
-		cmd_ifs.close();
-
-		return;
+  cmd_ifs.close();
 }
 
 void
@@ -1090,23 +1085,22 @@ Terminal::process_command(std::string & command, std::ostringstream & os)
   } else if (tokens[0] == "check") {
     pop_front(tokens);
     process_check(tokens, os);
-		} else if (tokens[0] == "help" ||
-													tokens[0] == "?") {
-		  pop_front(tokens);
-				process_help(tokens, os);
-		} else if (tokens[0] == "source") {
-				if (!inside_source) {
-						inside_source = true;
-						pop_front(tokens);
-						process_source(tokens, os);
-						finish_parsing = true;
-						inside_source = false;
-				} else {
-						os << "Nested \"source\" commands not allowed"<< std::endl;
-						finish_parsing = true;
-				}
-		} else if (tokens[0] == "quit") {
-				finish_parsing = true;
+  } else if ((tokens[0] == "help") || (tokens[0] == "?")) {
+    pop_front(tokens);
+    process_help(tokens, os);
+  } else if (tokens[0] == "source") {
+    if (!inside_source) {
+      inside_source = true;
+      pop_front(tokens);
+      process_source(tokens, os);
+      finish_parsing = true;
+      inside_source = false;
+    } else {
+      os << "Nested \"source\" commands not allowed" << std::endl;
+      finish_parsing = true;
+    }
+  } else if (tokens[0] == "quit") {
+    finish_parsing = true;
   } else {
     os << "Command not found" << std::endl;
   }

--- a/plansys2_terminal/test/CMakeLists.txt
+++ b/plansys2_terminal/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-ament_add_gtest(terminal_test terminal_test.cpp)
+ament_add_gtest(terminal_test terminal_test.cpp TIMEOUT 120)
 ament_target_dependencies(terminal_test ${dependencies})
 target_link_libraries(terminal_test terminal readline)
 

--- a/plansys2_terminal/test/pddl/commands
+++ b/plansys2_terminal/test/pddl/commands
@@ -1,0 +1,39 @@
+set instance leia robot
+set instance entrance room
+set instance kitchen room
+set instance bedroom room
+set instance dinning room
+set instance bathroom room
+set instance chargingroom room
+
+set predicate (connected entrance dinning)
+set predicate (connected dinning entrance)
+set predicate (connected dinning kitchen)
+set predicate (connected kitchen dinning)
+set predicate (connected dinning bedroom)
+set predicate (connected bedroom dinning)
+set predicate (connected bathroom bedroom)
+set predicate (connected bedroom bathroom)
+set predicate (connected chargingroom kitchen)
+set predicate (connected kitchen chargingroom)
+set predicate (charging_point_at chargingroom)
+set predicate (battery_low leia)
+set predicate (robot_at leia entrance)
+
+set goal (and(robot_at leia bathroom))
+
+quit
+
+get plan
+
+run
+
+get plan
+
+run (move leia entrance dinning)
+run (askcharge leia entrance)
+
+run (move leia bedroom kitchen)
+
+remove predicate battery_full leia
+set predicate battery_low leia

--- a/plansys2_terminal/test/pddl/plan
+++ b/plansys2_terminal/test/pddl/plan
@@ -1,0 +1,6 @@
+ 0.000:   (askcharge leia entrance chargingroom)  [5.000]
+ 5.001:   (charge leia chargingroom)      [5.000]
+10.002:  (move leia chargingroom kitchen)        [5.000]
+15.003:  (move leia kitchen dinning)     [5.000]
+20.004:  (move leia dinning bedroom)     [5.000]
+25.005: (move leia bedroom bathroom)    [5.000]

--- a/plansys2_terminal/test/terminal_test.cpp
+++ b/plansys2_terminal/test/terminal_test.cpp
@@ -17,6 +17,7 @@
 #include <vector>
 #include <sstream>
 #include <map>
+#include <algorithm>
 
 #include "rclcpp/rclcpp.hpp"
 #include "ament_index_cpp/get_package_share_directory.hpp"
@@ -34,6 +35,48 @@
 #include "plansys2_terminal/Terminal.hpp"
 
 #include "gtest/gtest.h"
+
+using namespace std::chrono_literals;
+
+class ActT : public plansys2::ActionExecutorClient
+{
+public:
+  ActT()
+  : plansys2::ActionExecutorClient("None", 1s)
+  {
+    progress_ = 0.0;
+    name_ = std::string("None");
+  }
+  explicit ActT(const std::string name)
+  : plansys2::ActionExecutorClient(name, 1s)
+  {
+    progress_ = 0.0;
+    name_ = name;
+  }
+
+private:
+  void do_work()
+  {
+    if (progress_ < 1.0) {
+      progress_ += 0.2;
+      send_feedback(progress_, name_ + " running");
+    } else {
+      finish(true, 1.0, name_ + " completed");
+
+      progress_ = 0.0;
+      std::cout << std::endl;
+    }
+
+    std::cout << "\r\e[K" << std::flush;
+    std::cout << "Requesting for " << name_ <<
+      "... [" << std::min(100.0, progress_ * 100.0) << "%]  " <<
+      std::flush;
+  }
+
+  float progress_;
+  std::string name_;
+};
+
 
 class TerminalTestCase : public ::testing::Test
 {
@@ -176,6 +219,18 @@ public:
   {
     method_executed_["process_run"] = true;
     Terminal::process_run(command, os);
+  }
+
+  void process_run_planfrom(std::vector<std::string> & command, std::ostringstream & s)
+  {
+    method_executed_["process_run_planfrom"] = true;
+    Terminal::process_run(command, s);
+  }
+
+  void process_source(std::vector<std::string> & command, std::ostringstream & s)
+  {
+    method_executed_["process_source"] = true;
+    Terminal::process_source(command, s);
   }
 
   void process_check(std::vector<std::string> & command, std::ostringstream & os)
@@ -765,9 +820,17 @@ TEST_F(TerminalTestCase, check_actors)
   auto charge_actor_1_node = plansys2::ActionExecutorClient::make_shared("charge", 100ms);
 
   move_actor_1_node->set_parameter({"action_name", "move"});
+  move_actor_1_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+
   move_actor_2_node->set_parameter({"action_name", "move"});
+  move_actor_2_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+
   ask_charge_actor_1_node->set_parameter({"action_name", "askcharge"});
+  ask_charge_actor_1_node->trigger_transition(
+    lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+
   charge_actor_1_node->set_parameter({"action_name", "charge"});
+  charge_actor_1_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
 
   std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_terminal");
 
@@ -838,6 +901,166 @@ TEST_F(TerminalTestCase, check_actors)
     "\t[charge] charge\tREADY\n"
     "\t[move_1] move\tREADY\n"
     "\t[move_2] move\tREADY\n");
+
+  exe.cancel();
+  t.join();
+}
+
+TEST_F(TerminalTestCase, source_run_plan)
+{
+  auto test_node = rclcpp::Node::make_shared("terminal_node_test");
+
+  auto domain_node = std::make_shared<plansys2::DomainExpertNode>();
+  auto problem_node = std::make_shared<plansys2::ProblemExpertNode>();
+  auto planner_node = std::make_shared<plansys2::PlannerNode>();
+  auto executor_node = std::make_shared<plansys2::ExecutorNode>();
+
+  auto problem_client = std::make_shared<plansys2::ProblemExpertClient>();
+
+  using namespace std::chrono_literals;
+
+  auto move_actor_1_node = std::make_shared<ActT>("move");
+  auto ask_charge_actor_1_node = std::make_shared<ActT>("ask_charge");
+  auto charge_actor_1_node = std::make_shared<ActT>("charge");
+
+  move_actor_1_node->set_parameter({"action_name", "move"});
+  move_actor_1_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  ask_charge_actor_1_node->set_parameter({"action_name", "askcharge"});
+  ask_charge_actor_1_node->trigger_transition(
+    lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  charge_actor_1_node->set_parameter({"action_name", "charge"});
+  charge_actor_1_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+
+  std::string pkgpath = ament_index_cpp::get_package_share_directory("plansys2_terminal");
+
+  domain_node->set_parameter({"model_file", pkgpath + "/pddl/simple_example.pddl"});
+  problem_node->set_parameter({"model_file", pkgpath + "/pddl/simple_example.pddl"});
+
+  std::string cmd_file = pkgpath + "/pddl/commands";
+  std::string plan_file = pkgpath + "/pddl/plan";
+
+  rclcpp::executors::MultiThreadedExecutor exe(rclcpp::ExecutorOptions(), 16, true);
+  ASSERT_GT(exe.get_number_of_threads(), 15u);
+
+  exe.add_node(domain_node->get_node_base_interface());
+  exe.add_node(problem_node->get_node_base_interface());
+  exe.add_node(planner_node->get_node_base_interface());
+  exe.add_node(executor_node->get_node_base_interface());
+
+  exe.add_node(move_actor_1_node->get_node_base_interface());
+  exe.add_node(ask_charge_actor_1_node->get_node_base_interface());
+  exe.add_node(charge_actor_1_node->get_node_base_interface());
+
+  std::thread t([&]() {
+      exe.spin();
+    });
+
+  domain_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  problem_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  planner_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  executor_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+
+  move_actor_1_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  ask_charge_actor_1_node->trigger_transition(
+    lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+  charge_actor_1_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = test_node->now();
+    while ((test_node->now() - start).seconds() < 0.5) {
+      rate.sleep();
+    }
+  }
+
+  domain_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  rclcpp_lifecycle::State state = problem_node->trigger_transition(
+    lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+  std::string stateLabel = state.label();
+
+  planner_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+  executor_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = test_node->now();
+    while ((test_node->now() - start).seconds() < 1.0) {
+      rate.sleep();
+    }
+  }
+
+  auto terminal_node = std::make_shared<TerminalTest>();
+  terminal_node->init();
+
+  {
+    std::ostringstream os;
+    // std::vector<std::string> command = {cmd_file, std::string("1")};
+    std::vector<std::string> command = {cmd_file};
+    terminal_node->process_source(command, os);
+    ASSERT_TRUE(terminal_node->method_executed_["process_source"]);
+    ASSERT_EQ(os.str(), "");
+  }
+
+  ASSERT_EQ(problem_client->getInstances().size(), 7);
+  ASSERT_EQ(problem_client->getPredicates().size(), 13);
+  ASSERT_EQ(problem_client->getFunctions().size(), 0);
+
+  {
+    auto ins_1 = problem_client->getInstance("leia");
+    ASSERT_TRUE(ins_1.has_value());
+    ASSERT_EQ(ins_1.value().name, "leia");
+    ASSERT_EQ(ins_1.value().type, "robot");
+  }
+
+  {
+    std::vector<std::string> rooms = {"entrance", "kitchen", "bedroom",
+      "dinning", "bathroom", "chargingroom"};
+    for (auto room_name : rooms) {
+      auto ins_2 = problem_client->getInstance(room_name);
+      ASSERT_TRUE(ins_2.has_value());
+      ASSERT_EQ(ins_2.value().name, room_name);
+      ASSERT_EQ(ins_2.value().type, "room");
+    }
+    terminal_node->reset_executions();
+  }
+
+  ASSERT_EQ(parser::pddl::toString(problem_client->getGoal()), "(and (robot_at leia bathroom))");
+
+  {
+    std::ostringstream os;
+    std::vector<std::string> command = {std::string("planfrom"), plan_file};
+    terminal_node->process_run_planfrom(command, os);
+    ASSERT_TRUE(terminal_node->method_executed_["process_run_planfrom"]);
+  }
+
+  terminal_node->reset_executions();
+
+  domain_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+  problem_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+  planner_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+  executor_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = test_node->now();
+    while ((test_node->now() - start).seconds() < 0.5) {
+      rate.sleep();
+    }
+  }
+
+  domain_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_INACTIVE_SHUTDOWN);
+  problem_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_INACTIVE_SHUTDOWN);
+  planner_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_INACTIVE_SHUTDOWN);
+  executor_node->trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_INACTIVE_SHUTDOWN);
+
+  {
+    rclcpp::Rate rate(10);
+    auto start = test_node->now();
+    while ((test_node->now() - start).seconds() < 0.5) {
+      rate.sleep();
+    }
+  }
 
   exe.cancel();
   t.join();

--- a/plansys2_terminal/test/terminal_test.cpp
+++ b/plansys2_terminal/test/terminal_test.cpp
@@ -221,9 +221,9 @@ public:
     Terminal::process_run(command, os);
   }
 
-  void process_run_planfrom(std::vector<std::string> & command, std::ostringstream & s)
+  void process_run_planfile(std::vector<std::string> & command, std::ostringstream & s)
   {
-    method_executed_["process_run_planfrom"] = true;
+    method_executed_["process_run_planfile"] = true;
     Terminal::process_run(command, s);
   }
 
@@ -1029,9 +1029,9 @@ TEST_F(TerminalTestCase, source_run_plan)
 
   {
     std::ostringstream os;
-    std::vector<std::string> command = {std::string("planfrom"), plan_file};
-    terminal_node->process_run_planfrom(command, os);
-    ASSERT_TRUE(terminal_node->method_executed_["process_run_planfrom"]);
+    std::vector<std::string> command = {std::string("plan-file"), plan_file};
+    terminal_node->process_run_planfile(command, os);
+    ASSERT_TRUE(terminal_node->method_executed_["process_run_planfile"]);
   }
 
   terminal_node->reset_executions();


### PR DESCRIPTION
This PR addresses #194 by adding 
- a help command
- the source command to load commands from a file
- extended run command with planfrom to read a file from a file
- added tests for the source/extended run (all the tests pass)