### PR TITLE
Generalize is parallelizable

### DIFF
--- a/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
+++ b/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
@@ -122,6 +122,8 @@ protected:
     std::vector<plansys2::Function> & functions) const;
   bool is_parallelizable(
     const plansys2::ActionStamped & action,
+    const std::vector<plansys2::Predicate> & predicates,
+    const std::vector<plansys2::Function> & functions,
     const std::list<GraphNode::Ptr> & ret) const;
 
   std::string get_flow_tree(

--- a/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
+++ b/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
@@ -287,9 +287,8 @@ BTBuilder::get_roots(
   auto it = action_sequence.begin();
   while (it != action_sequence.end()) {
     const auto & action = *it;
-    if (is_action_executable(
-        action, predicates,
-        functions) && is_parallelizable(action, predicates, functions, ret))
+    if (is_action_executable(action, predicates, functions) &&
+      is_parallelizable(action, predicates, functions, ret))
     {
       auto new_root = GraphNode::make_shared();
       new_root->action = action;

--- a/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
+++ b/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
@@ -218,46 +218,38 @@ BTBuilder::get_node_satisfy(
 bool
 BTBuilder::is_parallelizable(
   const plansys2::ActionStamped & action,
-  const std::list<GraphNode::Ptr> & ret) const
+  const std::vector<plansys2::Predicate> & predicates,
+  const std::vector<plansys2::Function> & functions,
+  const std::list<GraphNode::Ptr> & nodes) const
 {
-  std::vector<plansys2_msgs::msg::Node> action_requirements;
-  std::vector<plansys2_msgs::msg::Node> action_effects;
-  parser::pddl::getPredicates(action_requirements, action.action->at_start_requirements);
-  parser::pddl::getPredicates(action_requirements, action.action->over_all_requirements);
-  parser::pddl::getPredicates(action_requirements, action.action->at_end_requirements);
-  parser::pddl::getPredicates(action_effects, action.action->at_start_effects);
-  parser::pddl::getPredicates(action_effects, action.action->at_end_effects);
+  // Apply the effects of the new action.
+  auto preds = predicates;
+  auto funcs = functions;
+  apply(action.action->at_start_effects, preds, funcs);
+  apply(action.action->at_end_effects, preds, funcs);
 
-  for (const auto & other : ret) {
-    std::vector<plansys2_msgs::msg::Node> other_requirements;
-    std::vector<plansys2_msgs::msg::Node> other_effects;
-    parser::pddl::getPredicates(other_requirements, other->action.action->at_start_requirements);
-    parser::pddl::getPredicates(other_requirements, other->action.action->over_all_requirements);
-    parser::pddl::getPredicates(other_requirements, action.action->at_end_requirements);
-    parser::pddl::getPredicates(other_effects, other->action.action->at_start_effects);
-    parser::pddl::getPredicates(other_effects, other->action.action->at_end_effects);
-
-    for (const auto & action_effect : action_effects) {
-      for (const auto & other_requirement : other_requirements) {
-        if (parser::pddl::toString(action_effect) ==
-          parser::pddl::toString(other_requirement) &&
-          action_effect.negate != other_requirement.negate)
-        {
-          return false;
-        }
-      }
+  // Check the requirements of the actions in the input set.
+  for (const auto & other : nodes) {
+    if (!(check(other->action.action->at_start_requirements, preds, funcs) &&
+          check(other->action.action->over_all_requirements, preds, funcs) &&
+          check(other->action.action->at_end_requirements, preds, funcs))) {
+      return false;
     }
+  }
 
-    for (const auto & action_requirement : action_requirements) {
-      for (const auto & other_effect : other_effects) {
-        if (parser::pddl::toString(action_requirement) ==
-          parser::pddl::toString(other_effect) &&
-          action_requirement.negate != other_effect.negate)
-        {
-          return false;
-        }
-      }
-    }
+  // Apply the effects of the actions in the input set.
+  preds = predicates;
+  funcs = functions;
+  for (const auto & other : nodes) {
+    apply(other->action.action->at_start_effects, preds, funcs);
+    apply(other->action.action->at_end_effects, preds, funcs);
+  }
+
+  // Check the requirements of the new action.
+  if (!(check(action.action->at_start_requirements, preds, funcs) &&
+        check(action.action->over_all_requirements, preds, funcs) &&
+        check(action.action->at_end_requirements, preds, funcs))) {
+    return false;
   }
 
   return true;
@@ -293,7 +285,7 @@ BTBuilder::get_roots(
   auto it = action_sequence.begin();
   while (it != action_sequence.end()) {
     const auto & action = *it;
-    if (is_action_executable(action, predicates, functions) && is_parallelizable(action, ret)) {
+    if (is_action_executable(action, predicates, functions) && is_parallelizable(action, predicates, functions, ret)) {
       auto new_root = GraphNode::make_shared();
       new_root->action = action;
       new_root->node_num = node_counter++;

--- a/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
+++ b/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
@@ -270,7 +270,7 @@ BTBuilder::is_parallelizable(
       return false;
     }
 
-    // Apply the "at end" effects of the action in the input set.
+    // Apply the "at end" effects of the action.
     apply(other->action.action->at_end_effects, preds, funcs);
 
     // Check the requirements of the new action.

--- a/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
+++ b/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
@@ -231,8 +231,9 @@ BTBuilder::is_parallelizable(
   // Check the requirements of the actions in the input set.
   for (const auto & other : nodes) {
     if (!(check(other->action.action->at_start_requirements, preds, funcs) &&
-          check(other->action.action->over_all_requirements, preds, funcs) &&
-          check(other->action.action->at_end_requirements, preds, funcs))) {
+      check(other->action.action->over_all_requirements, preds, funcs) &&
+      check(other->action.action->at_end_requirements, preds, funcs)))
+    {
       return false;
     }
   }
@@ -247,8 +248,9 @@ BTBuilder::is_parallelizable(
 
   // Check the requirements of the new action.
   if (!(check(action.action->at_start_requirements, preds, funcs) &&
-        check(action.action->over_all_requirements, preds, funcs) &&
-        check(action.action->at_end_requirements, preds, funcs))) {
+    check(action.action->over_all_requirements, preds, funcs) &&
+    check(action.action->at_end_requirements, preds, funcs)))
+  {
     return false;
   }
 
@@ -285,7 +287,10 @@ BTBuilder::get_roots(
   auto it = action_sequence.begin();
   while (it != action_sequence.end()) {
     const auto & action = *it;
-    if (is_action_executable(action, predicates, functions) && is_parallelizable(action, predicates, functions, ret)) {
+    if (is_action_executable(
+        action, predicates,
+        functions) && is_parallelizable(action, predicates, functions, ret))
+    {
       auto new_root = GraphNode::make_shared();
       new_root->action = action;
       new_root->node_num = node_counter++;


### PR DESCRIPTION
The is_parallelizable function in BTBuilder currently only checks for contradictions between predicate effects and requirements. This PR will generalize the is_parallelizable function to work with functions as well.