### PR TITLE
fix-getSubtrees: Fixing bug in getSubtrees function in Utils.cpp.

### DIFF
--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Utils.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Utils.cpp
@@ -882,7 +882,6 @@ std::vector<uint32_t> getSubtreeIds(const plansys2_msgs::msg::Tree & tree)
     case plansys2_msgs::msg::Node::AND: {
         return tree.nodes.front().children;
       }
-
     default:
       std::cerr << "getSubtreeIds: Error parsing expresion [" << toString(tree) << "]" << std::endl;
   }

--- a/plansys2_pddl_parser/src/plansys2_pddl_parser/Utils.cpp
+++ b/plansys2_pddl_parser/src/plansys2_pddl_parser/Utils.cpp
@@ -899,6 +899,7 @@ std::vector<plansys2_msgs::msg::Tree> getSubtrees(const plansys2_msgs::msg::Tree
     plansys2_msgs::msg::Tree subtree;
     subtree.nodes.push_back(tree.nodes[node_id]);
     subtree.nodes[0].node_id = 0;
+    subtree.nodes[0].children.clear();
     getSubtreeChildren(subtree, tree, node_id, 0);
     subtrees.push_back(subtree);
   }
@@ -912,6 +913,7 @@ void getSubtreeChildren(plansys2_msgs::msg::Tree & subtree, const plansys2_msgs:
     subtree.nodes[subtree_parent].children.push_back(subtree_size);
     subtree.nodes.push_back(tree.nodes[child_id]);
     subtree.nodes.back().node_id = subtree_size;
+    subtree.nodes.back().children.clear();
     getSubtreeChildren(subtree, tree, child_id, subtree_size);
   }
 }


### PR DESCRIPTION
I found a bug in the getSubtrees function in plansys2_pddl_parser/Utils.cpp. This function retrieves a set of PDDL subtrees from a parent tree. When creating a subtree object, the nodes are reindexed. Obviously, this requires that the children vector also be updated. In the current implementation, we push the new values onto the children vector without clearing the vector first. This results in a children vector with erroneous indices at the front. To correct this, we simply need to clear the children vector prior to pushing the new indices.

As far as I can tell this function is currently only used to retrieve subgoals in the Problem Expert. Most often these are simple predicates without any children. This may explain why we did not find this bug sooner.