### PR TITLE
Fix typo in cascade_lifecycle repo name

### DIFF
--- a/dependency_repos.repos
+++ b/dependency_repos.repos
@@ -1,5 +1,5 @@
 repositories:
-  cascade_filecycle:
+  cascade_lifecycle:
     type: git
     url: https://github.com/fmrico/cascade_lifecycle.git
     version: galactic-devel


### PR DESCRIPTION
How i found that:
```
$ vcs import src < src/ros2_planning_system/dependency_repos.repos
..
=== src/cascade_filecycle (git) ===
Cloning into '.'...
=== src/popf (git) ===
Cloning into '.'...

$ colcon build
[0.427s] ERROR:colcon:colcon build: Duplicate package names not supported:
- cascade_lifecycle_msgs:
  - src/cascade_filecycle/cascade_lifecycle_msgs
  - src/cascade_lifecycle/cascade_lifecycle_msgs
- rclcpp_cascade_lifecycle:
  - src/cascade_filecycle/rclcpp_cascade_lifecycle
  - src/cascade_lifecycle/rclcpp_cascade_lifecycle
  ```