### PR TITLE
Plan dotgraph color bug

### DIFF
--- a/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
+++ b/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
@@ -135,7 +135,7 @@ protected:
     GraphNode::Ptr node, std::shared_ptr<std::map<std::string,
     ActionExecutionInfo>> action_map, int level = 0);
   ActionExecutor::Status get_action_status(
-    std::shared_ptr<plansys2_msgs::msg::DurativeAction> action,
+    ActionStamped action,
     std::shared_ptr<std::map<std::string, ActionExecutionInfo>> action_map);
   void addDotGraphLegend(
     std::stringstream & ss, int tab_level, int level_counter,

--- a/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
+++ b/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
@@ -839,7 +839,6 @@ ActionExecutor::Status BTBuilder::get_action_status(
   ActionStamped action_stamped,
   std::shared_ptr<std::map<std::string, ActionExecutionInfo>> action_map)
 {
-  std::shared_ptr<plansys2_msgs::msg::DurativeAction> action = action_stamped.action;
   auto index = "(" + parser::pddl::nameActionsToString(action_stamped.action) + "):" +
     std::to_string(static_cast<int>(action_stamped.time * 1000));
   if ((*action_map)[index].action_executor) {

--- a/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
+++ b/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
@@ -811,7 +811,7 @@ BTBuilder::get_node_dotgraph(
     "\"";
   ss << "labeljust=c,style=filled";
 
-  auto status = get_action_status(node->action.action, action_map);
+  auto status = get_action_status(node->action, action_map);
   switch (status) {
     case ActionExecutor::RUNNING:
       ss << ",color=blue,fillcolor=skyblue";
@@ -836,17 +836,17 @@ BTBuilder::get_node_dotgraph(
 }
 
 ActionExecutor::Status BTBuilder::get_action_status(
-  std::shared_ptr<plansys2_msgs::msg::DurativeAction> action,
+  ActionStamped action_stamped,
   std::shared_ptr<std::map<std::string, ActionExecutionInfo>> action_map)
 {
-  for (const auto & action_pair : *action_map) {
-    if (parser::pddl::nameActionsToString(action_pair.second.durative_action_info) ==
-      parser::pddl::nameActionsToString(action))
-    {
-      return action_pair.second.action_executor->get_internal_status();
-    }
+  std::shared_ptr<plansys2_msgs::msg::DurativeAction> action = action_stamped.action;
+  auto index = "(" + parser::pddl::nameActionsToString(action_stamped.action) + "):" +
+    std::to_string(static_cast<int>(action_stamped.time * 1000));
+  if ((*action_map)[index].action_executor) {
+    return (*action_map)[index].action_executor->get_internal_status();
+  } else {
+    return ActionExecutor::IDLE;
   }
-  return ActionExecutor::IDLE;
 }
 
 void BTBuilder::addDotGraphLegend(


### PR DESCRIPTION
More accurately getting the status of an action by including the action's start time in the index for coloring the dotgraph.

*Testing*
* Basing the test off of the simple example in the ros2_planning_system_examples repository.
* Create a workspace from this repos file: 
[plansys2-dotgraph-bug.repos.txt](https://github.com/IntelligentRoboticsLabs/ros2_planning_system/files/8412136/plansys2-dotgraph-bug.repos.txt)
* Terminal 1: `ros2 launch plansys2_simple_example plansys2_simple_example_launch.py domain:=domain_charging`
* Terminal 2: `ros2 run plansys2_terminal plansys2_terminal --ros-args -p problem_file:=./install/plansys2_simple_example/share/plansys2_simple_example/pddl/charging_problem.pddl`
* Terminal 3: `ros2 run rqt_dotgraph rqt_dotgraph`
* After you type run and hit enter in Terminal 4 and the plan starts executing, you should see the plan in the rqt_dotgraph window. It should look something like this:
![plansys2-dotgraph-bug-fixed](https://user-images.githubusercontent.com/42847381/161606113-45130b86-5cba-47b8-957c-3d01fcf56ec1.png)
Without this fix, it will look like this:
![plansys2-dotgraph-bug](https://user-images.githubusercontent.com/42847381/161606161-c30d41b1-5a09-4760-9fe6-c5a182c4cecc.png)

