### PR TITLE
Plan-to-Action Graph Bug Fix

### DIFF
--- a/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
+++ b/plansys2_executor/include/plansys2_executor/BTBuilder.hpp
@@ -136,7 +136,7 @@ protected:
     GraphNode::Ptr node,
     std::list<std::string> & used_nodes,
     int level = 0);
-  std::string get_flow_dotgraph(GraphNode::Ptr node, int level = 0);
+  void get_flow_dotgraph(GraphNode::Ptr node, std::set<std::string> & edges);
   std::string get_node_dotgraph(
     GraphNode::Ptr node, std::shared_ptr<std::map<std::string,
     ActionExecutionInfo>> action_map, int level = 0);

--- a/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
+++ b/plansys2_executor/src/plansys2_executor/BTBuilder.cpp
@@ -66,8 +66,7 @@ BTBuilder::is_action_executable(
   std::vector<plansys2::Function> & functions) const
 {
   return check(action.action->at_start_requirements, predicates, functions) &&
-         check(action.action->over_all_requirements, predicates, functions) &&
-         check(action.action->at_end_requirements, predicates, functions);
+         check(action.action->over_all_requirements, predicates, functions);
 }
 
 GraphNode::Ptr
@@ -130,7 +129,6 @@ BTBuilder::get_node_contradict(
   if (is_action_executable(current->action, predicates, functions)) {
     // Apply the effects
     apply(current->action.action->at_start_effects, predicates, functions);
-    apply(current->action.action->at_end_effects, predicates, functions);
 
     // Look for a contradiction
     if (!is_action_executable(node->action, predicates, functions)) {
@@ -151,25 +149,10 @@ BTBuilder::is_parallelizable(
   const std::vector<plansys2::Function> & functions,
   const std::list<GraphNode::Ptr> & nodes) const
 {
-  // Since we do not know exactly when 2 parallel actions will overlap,
-  // we must check for contradictions at any point in time.
-  // For example, in the case of a unary resource an "at start" effect
-  // may trun on a predicate, but an "at end" effect may turn it off.
-
   // Apply the "at start" effects of the new action.
   auto preds = predicates;
   auto funcs = functions;
   apply(action.action->at_start_effects, preds, funcs);
-
-  // Check the requirements of the actions in the input set.
-  for (const auto & other : nodes) {
-    if (!is_action_executable(other->action, preds, funcs)) {
-      return false;
-    }
-  }
-
-  // Apply the "at end" effects of the new action.
-  apply(action.action->at_end_effects, preds, funcs);
 
   // Check the requirements of the actions in the input set.
   for (const auto & other : nodes) {
@@ -184,14 +167,6 @@ BTBuilder::is_parallelizable(
     preds = predicates;
     funcs = functions;
     apply(other->action.action->at_start_effects, preds, funcs);
-
-    // Check the requirements of the new action.
-    if (!is_action_executable(action, preds, funcs)) {
-      return false;
-    }
-
-    // Apply the "at end" effects of the action.
-    apply(other->action.action->at_end_effects, preds, funcs);
 
     // Check the requirements of the new action.
     if (!is_action_executable(action, preds, funcs)) {
@@ -292,7 +267,7 @@ BTBuilder::prune_backwards(GraphNode::Ptr new_node, GraphNode::Ptr node_satisfy)
   auto it = node_satisfy->out_arcs.begin();
   while (it != node_satisfy->out_arcs.end()) {
     if (*it == new_node) {
-      (*it)->in_arcs.remove(*it);
+      new_node->in_arcs.remove(node_satisfy);
       it = node_satisfy->out_arcs.erase(it);
     } else {
       ++it;
@@ -448,10 +423,6 @@ BTBuilder::get_graph(const plansys2_msgs::msg::Plan & current_plan)
     action_sequence.erase(action_sequence.begin());
   }
 
-  std::list<GraphNode::Ptr> used_nodes;
-  for (auto & root : graph->roots) {
-    prune_forward(root, used_nodes);
-  }
   return graph;
 }
 
@@ -459,6 +430,11 @@ std::string
 BTBuilder::get_tree(const plansys2_msgs::msg::Plan & current_plan)
 {
   auto action_graph = get_graph(current_plan);
+
+  std::list<GraphNode::Ptr> used_actions;
+  for (auto & root : action_graph->roots) {
+    prune_forward(root, used_actions);
+  }
 
   std::string bt_plan;
 
@@ -566,10 +542,15 @@ BTBuilder::get_dotgraph(
     }
   }
 
-  tab_level = 1;
   // define the edges
+  std::set<std::string> edges;
   for (const auto & graph_root : action_graph->roots) {
-    ss << get_flow_dotgraph(graph_root, tab_level);
+    get_flow_dotgraph(graph_root, edges);
+  }
+
+  tab_level = 1;
+  for (const auto & edge : edges) {
+    ss << t(tab_level) << edge;
   }
 
   if (enable_legend) {
@@ -632,20 +613,17 @@ BTBuilder::get_flow_tree(
   return ret;
 }
 
-std::string
+void
 BTBuilder::get_flow_dotgraph(
   GraphNode::Ptr node,
-  int level)
+  std::set<std::string> & edges)
 {
-  std::stringstream ss;
-
-  for (const auto & child_node : node->out_arcs) {
-    ss << t(level);
-    ss << node->node_num << "->" << child_node->node_num << ";\n";
-    ss << get_flow_dotgraph(child_node, level);
+  for (const auto & arc : node->out_arcs) {
+    std::string edge = std::to_string(node->node_num) + "->" + std::to_string(arc->node_num) +
+      ";\n";
+    edges.insert(edge);
+    get_flow_dotgraph(arc, edges);
   }
-
-  return ss.str();
 }
 
 std::string
@@ -854,10 +832,14 @@ BTBuilder::print_graph(const plansys2::Graph::Ptr & graph) const
 void
 BTBuilder::print_node_csv(const plansys2::GraphNode::Ptr & node, uint32_t root_num) const
 {
-  std::cerr << root_num << ", " <<
-    node->node_num << ", " <<
-    node->level_num << ", " <<
-    parser::pddl::nameActionsToString(node->action.action) << std::endl;
+  std::string out_str = std::to_string(root_num) + ", " +
+    std::to_string(node->node_num) + ", " +
+    std::to_string(node->level_num) + ", " +
+    parser::pddl::nameActionsToString(node->action.action);
+  for (const auto & arc : node->out_arcs) {
+    out_str = out_str + ", " + parser::pddl::nameActionsToString(arc->action.action);
+  }
+  std::cerr << out_str << std::endl;
   for (const auto & out : node->out_arcs) {
     print_node_csv(out, root_num);
   }

--- a/plansys2_executor/test/test_data/elevator_graph.csv
+++ b/plansys2_executor/test/test_data/elevator_graph.csv
@@ -1,12 +1,15 @@
-0, 0, 0, move-down e2 n5 n4
-0, 2, 1, board p3 n4 e2
-0, 5, 3, move-down e2 n4 n3
-0, 6, 4, move-down e2 n3 n2
-0, 8, 6, move-down e2 n2 n1
+0, 0, 0, move-down e2 n5 n4, board p3 n4 e2
+0, 2, 1, board p3 n4 e2, move-down e2 n4 n3
+0, 5, 3, move-down e2 n4 n3, move-down e2 n3 n2
+0, 6, 4, move-down e2 n3 n2, move-down e2 n2 n1
+0, 8, 6, move-down e2 n2 n1, leave p3 n1 e2
 0, 11, 8, leave p3 n1 e2
-1, 1, 0, move-up e1 n1 n2
-1, 3, 2, board p1 n2 e1
-1, 7, 5, move-down e1 n2 n1
+1, 1, 0, move-up e1 n1 n2, board p1 n2 e1, board p2 n2 e1
+1, 3, 2, board p1 n2 e1, move-down e1 n2 n1
+1, 7, 5, move-down e1 n2 n1, leave p1 n1 e1, leave p2 n1 e1
 1, 9, 7, leave p1 n1 e1
 1, 10, 7, leave p2 n1 e1
-1, 4, 2, board p2 n2 e1
+1, 4, 2, board p2 n2 e1, move-down e1 n2 n1
+1, 7, 5, move-down e1 n2 n1, leave p1 n1 e1, leave p2 n1 e1
+1, 9, 7, leave p1 n1 e1
+1, 10, 7, leave p2 n1 e1

--- a/plansys2_executor/test/test_data/road_trip_graph.csv
+++ b/plansys2_executor/test/test_data/road_trip_graph.csv
@@ -1,8 +1,8 @@
-0, 0, 0, move herbie wp0 wp1
-0, 1, 1, visit herbie wp1
-0, 2, 2, move herbie wp1 rp0
-0, 3, 3, refuel herbie rp0
-0, 4, 4, move herbie rp0 wp3
-0, 5, 5, visit herbie wp3
-0, 6, 6, move herbie wp3 wp2
+0, 0, 0, move herbie wp0 wp1, visit herbie wp1
+0, 1, 1, visit herbie wp1, move herbie wp1 rp0
+0, 2, 2, move herbie wp1 rp0, refuel herbie rp0
+0, 3, 3, refuel herbie rp0, move herbie rp0 wp3
+0, 4, 4, move herbie rp0 wp3, visit herbie wp3
+0, 5, 5, visit herbie wp3, move herbie wp3 wp2
+0, 6, 6, move herbie wp3 wp2, visit herbie wp2
 0, 7, 7, visit herbie wp2


### PR DESCRIPTION
This pull request is in response to Issue #211.

To test whether 2 actions can be run in parallel, we (1) test whether each action is executable given the current state and (2) check whether the effects of one action will contradict the requirements of the other. This is good, but there is a problem in the current approach.

In the current approach, we check whether the "at end" effects of one action will contradict any of the conditions of the other action. However, @roveri-marco provided an example of a valid plan where two actions could be run in parallel in which an "at end" effect of one action contradicted an "at start" condition of the other. Logically, this makes sense. To test whether 2 actions can run in parallel, we should only need to check for contradictions between the "at start" effects and the "at start" and "over all" conditions. This PR fixes this bug

When working on the above bug, another bug was found in the prune_backwards function of BTBuilder. In this case, the superfluous parent nodes were not being correctly removed from the input arc set. This PR also fixes that bug.